### PR TITLE
Export getTypeScriptWorker & getJavaScriptWorker to monaco.languages.typescript

### DIFF
--- a/src/monaco.contribution.ts
+++ b/src/monaco.contribution.ts
@@ -121,6 +121,23 @@ const javascriptDefaults = new LanguageServiceDefaultsImpl(
 	{ allowNonTsExtensions: true, allowJs: true, target: ScriptTarget.Latest },
 	{ noSemanticValidation: true, noSyntaxValidation: false });
 
+function getTypeScriptWorker(): monaco.Promise<Worker> {
+	return new monaco.Promise((resolve, reject) => {
+ 		withMode((mode) => {
+ 			mode.getTypeScriptWorker()
+ 				.then(resolve, reject);
+ 		});
+ 	});
+}
+
+function getJavaScriptWorker(): monaco.Promise<Worker> {
+	return new monaco.Promise((resolve, reject) => {
+ 		withMode((mode) => {
+ 			mode.getJavaScriptWorker()
+ 				.then(resolve, reject);
+ 		});
+ 	});
+}
 
 // Export API
 function createAPI(): typeof monaco.languages.typescript {
@@ -131,7 +148,9 @@ function createAPI(): typeof monaco.languages.typescript {
 		ScriptTarget: ScriptTarget,
 		ModuleResolutionKind: ModuleResolutionKind,
 		typescriptDefaults: typescriptDefaults,
-		javascriptDefaults: javascriptDefaults
+		javascriptDefaults: javascriptDefaults,
+		getTypeScriptWorker: getTypeScriptWorker,
+		getJavaScriptWorker: getJavaScriptWorker
 	}
 }
 monaco.languages.typescript = createAPI();

--- a/src/monaco.d.ts
+++ b/src/monaco.d.ts
@@ -106,4 +106,7 @@ declare module monaco.languages.typescript {
 
     export var typescriptDefaults: LanguageServiceDefaults;
     export var javascriptDefaults: LanguageServiceDefaults;
+
+    export var getTypeScriptWorker: () => monaco.Promise<Worker>;
+    export var getJavaScriptWorker: () => monaco.Promise<Worker>;
 }


### PR DESCRIPTION
The idea behind this pull request is to enable and export the typescript compilation for multiple files. 

You can now create multiple models with:

```javascript
resourceUri = Monaco.Uri.file(filePath);
model = Monaco.editor.createModel(fileContent, language, resourceUri);
```
(will be good idea to cache those)

In this way, you will feed the typescriptService host with all your available files and then you can simply call:

```javascript
	Monaco.languages.typescript.getTypeScriptWorker()
            .then(function(worker) {
                worker(model.uri)
                      .then(function(client) {
                            client.getEmitOutput(model.uri.toString().then(function(r) {});
                      });
            });
```

Which will compile the file you have already created Model for.

We are attaching the function to the Monaco.languages.typescript object so we can use it for multiple files/models and not just the current one. 

As this is my first PR I want to make a small step before exposing the whole API (will probably iterate through the worker functions and add those to exports)

Related to https://github.com/Microsoft/monaco-editor/issues/35


