### PR TITLE
Add option to use persistent worker

### DIFF
--- a/src/mode.ts
+++ b/src/mode.ts
@@ -17,19 +17,21 @@ import IDisposable = monaco.IDisposable;
 let javaScriptWorker: (first: Uri, ...more: Uri[]) => Promise<TypeScriptWorker>;
 let typeScriptWorker: (first: Uri, ...more: Uri[]) => Promise<TypeScriptWorker>;
 
-export function setupTypeScript(defaults:LanguageServiceDefaultsImpl): void {
+export function setupTypeScript(defaults:LanguageServiceDefaultsImpl, stopWorkerWhenIdleFor?: number): void {
 	typeScriptWorker = setupMode(
 		defaults,
 		'typescript',
-		Language.TypeScript
+		Language.TypeScript,
+		stopWorkerWhenIdleFor
 	);
 }
 
-export function setupJavaScript(defaults:LanguageServiceDefaultsImpl): void {
+export function setupJavaScript(defaults:LanguageServiceDefaultsImpl, stopWorkerWhenIdleFor?: number): void {
 	javaScriptWorker = setupMode(
 		defaults,
 		'javascript',
-		Language.EcmaScript5
+		Language.EcmaScript5,
+		stopWorkerWhenIdleFor
 	);
 }
 
@@ -53,11 +55,11 @@ export function getTypeScriptWorker(): Promise<TypeScriptWorker> {
 	});
 }
 
-function setupMode(defaults:LanguageServiceDefaultsImpl, modeId:string, language:Language): (first: Uri, ...more: Uri[]) => Promise<TypeScriptWorker> {
+function setupMode(defaults:LanguageServiceDefaultsImpl, modeId:string, language:Language, stopWorkerWhenIdleFor?: number): (first: Uri, ...more: Uri[]) => Promise<TypeScriptWorker> {
 
 	let disposables: IDisposable[] = [];
 
-	const client = new WorkerManager(defaults);
+	const client = new WorkerManager(defaults, stopWorkerWhenIdleFor);
 	disposables.push(client);
 
 	const worker = (first: Uri, ...more: Uri[]): Promise<TypeScriptWorker> => {


### PR DESCRIPTION
Currently, we are loading multiple Models in the workers (mainly for cross-file completion purposes). However, if we are idle for 2 minutes we have to load those again. So easy solution would be the option to make the workers caring for ts/js be persistent or increase their idle timeout.

With this approach, we will have to make a custom monaco.contribution.ts file but the alternative would be exposing access to the workerManager from monaco.languages.typescript.