### PR TITLE
Add documentation support on hover

### DIFF
--- a/src/languageFeatures.ts
+++ b/src/languageFeatures.ts
@@ -317,10 +317,19 @@ export class QuickInfoAdapter extends Adapter implements monaco.languages.HoverP
 			if (!info) {
 				return;
 			}
+			let documentation = ts.displayPartsToString(info.documentation);
+			let tags = info.tags ? info.tags.map(tag => {
+				const label = `*@${tag.name}*`;
+				if (!tag.text) {
+					return label;
+				}
+				return label + (tag.text.match(/\r\n|\n/g) ? ' \n' + tag.text : ` - ${tag.text}`);
+			})
+			.join('  \n\n') : '';
 			let contents = ts.displayPartsToString(info.displayParts);
 			return {
 				range: this._textSpanToRange(resource, info.textSpan),
-				contents: [contents]
+				contents: [ contents, documentation + (tags ? '\n\n' + tags : '') ]
 			};
 		}));
 	}


### PR DESCRIPTION
This PR adds support for quick info documentation and tags, which is similar to the hover support provided by [vscode](https://github.com/Microsoft/vscode/blob/50657045aea63d19673e9d08773c96bac3da7453/extensions/typescript/src/features/hoverProvider.ts#L40).

An example for the following code:

```ts
/**
 * Some documentation
 * @pure non-standard tag
 * @deprecated which should be parsed
 */
function foo() {
	//
}
```

You get the following when hovering:

<img width="471" alt="_dojo_web-editor" src="https://user-images.githubusercontent.com/1282577/27257460-6373ebb0-538c-11e7-8bed-2be5bb18d3ec.png">

Resolves: Microsoft/monaco-editor#203
Resolves: Microsoft/monaco-editor#277
