### PR TITLE
Use Mardown code block for hover tooltip

### DIFF
--- a/src/languageFeatures.ts
+++ b/src/languageFeatures.ts
@@ -330,7 +330,7 @@ export class QuickInfoAdapter extends Adapter implements monaco.languages.HoverP
 			return {
 				range: this._textSpanToRange(resource, info.textSpan),
 				contents: [{
-					value: contents
+					value: '```js\n' + contents + '\n```\n'
 				}, {
 					value: documentation + (tags ? '\n\n' + tags : '')
 				}]


### PR DESCRIPTION
Fixes Microsoft/monaco-editor#802. Maybe we could add an option to register decorations for people using custom tokenizers, or is it already possible?

**`master`**
<img width="465" alt="screen shot 2018-05-13 at 03 18 46" src="https://user-images.githubusercontent.com/5746414/39962896-def6e660-565c-11e8-9280-27c5daf76b91.png">

**PR**
<img width="443" alt="screen shot 2018-05-13 at 03 17 34" src="https://user-images.githubusercontent.com/5746414/39962898-e4b22524-565c-11e8-8699-344d23d77575.png">
