### PR TITLE
more safe extra lib filePath generation

### DIFF
--- a/src/monaco.contribution.ts
+++ b/src/monaco.contribution.ts
@@ -42,7 +42,7 @@ export class LanguageServiceDefaultsImpl implements monaco.languages.typescript.
 
 	addExtraLib(content: string, filePath?: string): IDisposable {
 		if (typeof filePath === 'undefined') {
-			filePath = `ts:extralib-${Date.now()}`;
+			filePath = `ts:extralib-${Math.random().toString(36).substring(2, 15)}`;
 		}
 
 		if (this._extraLibs[filePath]) {


### PR DESCRIPTION
Hi!

When adding a bunch of libs without filePaths, some of them are sometimes added at the same ms so an error is thrown. I suggest to randomize autogenerated filePath a bit more.