### PR TITLE
Adds dts file to the dev folder

### DIFF
--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -4,6 +4,7 @@
     "moduleResolution": "node",
     "outDir": "../release/dev",
     "target": "es5",
+    "declaration": true,
     "lib": [
       "dom",
       "es5",


### PR DESCRIPTION
This adds the d.ts files to the dev parts of the output, which I _assume_ would then be passed through into the dev folder in the monaco-editor npm module. 

![Screen Shot 2019-07-25 at 10 24 11 AM](https://user-images.githubusercontent.com/49038/61882447-964e9200-aec6-11e9-8805-87ed804c73a6.png)
