### PR TITLE
Add a rename provider

### DIFF
--- a/src/tsMode.ts
+++ b/src/tsMode.ts
@@ -64,6 +64,7 @@ function setupMode(defaults: LanguageServiceDefaultsImpl, modeId: string): (firs
 	monaco.languages.registerDocumentSymbolProvider(modeId, new languageFeatures.OutlineAdapter(worker));
 	monaco.languages.registerDocumentRangeFormattingEditProvider(modeId, new languageFeatures.FormatAdapter(worker));
 	monaco.languages.registerOnTypeFormattingEditProvider(modeId, new languageFeatures.FormatOnTypeAdapter(worker));
+	monaco.languages.registerRenameProvider(modeId, new languageFeatures.RenameAdapter(worker));
 	new languageFeatures.DiagnostcsAdapter(defaults, modeId, worker);
 
 	return worker;

--- a/src/tsWorker.ts
+++ b/src/tsWorker.ts
@@ -196,6 +196,14 @@ export class TypeScriptWorker implements ts.LanguageServiceHost {
 		return Promise.resolve(this._languageService.getFormattingEditsAfterKeystroke(fileName, postion, ch, options));
 	}
 
+	findRenameLocations(fileName: string, positon: number, findInStrings: boolean, findInComments: boolean, providePrefixAndSuffixTextForRename: boolean): Promise<readonly ts.RenameLocation[]> {
+		return Promise.resolve(this._languageService.findRenameLocations(fileName, positon, findInStrings, findInComments, providePrefixAndSuffixTextForRename));
+	}
+
+	getRenameInfo(fileName: string, positon: number, options: ts.RenameInfoOptions): Promise<ts.RenameInfo> {
+		return Promise.resolve(this._languageService.getRenameInfo(fileName, positon, options));
+	}
+
 	getEmitOutput(fileName: string): Promise<ts.EmitOutput> {
 		return Promise.resolve(this._languageService.getEmitOutput(fileName));
 	}


### PR DESCRIPTION
This PR registers a `monaco.languages.RenameProvider` with the Monaco Editor for a safe way of renaming symbols. Feedback/recommendations welcome!

Fixes https://github.com/microsoft/monaco-editor/issues/300

The rename operations currently suffer from the same problem as code actions and cannot be undone (see https://github.com/microsoft/monaco-editor/issues/1548).

I also get the following warning on the browser console after the rename operation is applied. Any suggestions for the cause of that? (Monaco version 0.17.1)
![grafik](https://user-images.githubusercontent.com/25029871/63020297-0933a300-be9e-11e9-86eb-8fb49771ec53.png)

Thanks!
