### PR TITLE
Fix microsoft/monaco-editor#1576 update dependency to core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
       "dev": true
     },
     "monaco-editor-core": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor-core/-/monaco-editor-core-0.16.0.tgz",
-      "integrity": "sha512-8tm8vq0SVuQ+VXZFtPIEIronK3102SYCWe8wviWu/5TV4zlDQcf4YdzI6A4CrNqbUc46dD0ngijaKWoRSViI8g==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor-core/-/monaco-editor-core-0.18.0.tgz",
+      "integrity": "sha512-URcHNAqH9X2JvO2skkIisAL4XAcZXxrDC8kcyr453sXQpOHUxicZpXHQb4/arXGvxrWvei3a6zZzpdT1gjeVJA==",
       "dev": true
     },
     "monaco-languages": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/Microsoft/monaco-typescript/issues"
   },
   "devDependencies": {
-    "monaco-editor-core": "^0.16.0",
+    "monaco-editor-core": "^0.18.0",
     "monaco-languages": "^1.7.0",
     "monaco-plugin-helpers": "^1.0.2",
     "requirejs": "^2.3.6",

--- a/src/languageFeatures.ts
+++ b/src/languageFeatures.ts
@@ -316,7 +316,7 @@ export class SignatureHelpAdapter extends Adapter implements monaco.languages.Si
 
 	public signatureHelpTriggerCharacters = ['(', ','];
 
-	provideSignatureHelp(model: monaco.editor.IReadOnlyModel, position: Position, token: CancellationToken): Thenable<monaco.languages.SignatureHelp> {
+	provideSignatureHelp(model: monaco.editor.IReadOnlyModel, position: Position, token: CancellationToken): Thenable<monaco.languages.SignatureHelpResult> {
 		let resource = model.uri;
 		return this._worker(resource).then(worker => worker.getSignatureHelpItems(resource.toString(), this._positionToOffset(resource, position))).then(info => {
 
@@ -334,7 +334,6 @@ export class SignatureHelpAdapter extends Adapter implements monaco.languages.Si
 
 				let signature: monaco.languages.SignatureInformation = {
 					label: '',
-					documentation: null,
 					parameters: []
 				};
 
@@ -355,8 +354,10 @@ export class SignatureHelpAdapter extends Adapter implements monaco.languages.Si
 				ret.signatures.push(signature);
 			});
 
-			return ret;
-
+			return {
+				value: ret,
+				dispose() {}
+			};
 		});
 	}
 }
@@ -494,6 +495,7 @@ export class OutlineAdapter extends Adapter implements monaco.languages.Document
 					kind: <monaco.languages.SymbolKind>(outlineTypeTable[item.kind] || monaco.languages.SymbolKind.Variable),
 					range: this._textSpanToRange(resource, item.spans[0]),
 					selectionRange: this._textSpanToRange(resource, item.spans[0]),
+					tags: [],
 					containerName: containerLabel
 				};
 


### PR DESCRIPTION
Fixes microsoft/monaco-editor#1576

* Update dependency to monaco-editor-core to 0.18.0
* Fix typing errors:
    * SignatureHelpAdapter#provideSignatureHelp return a wrapped SignatureHelpResult
    * monaco.languages.DocumentSymbol has got a new property: tags

The tags are an array of `SymbolTag`s, and the only existing `SymbolTag` is "Deprecated".
I did not find any information about that in the `ts.NavigationBarItem`, so the tags
are always an empty array for now.