### PR TITLE
Add support to ignore certain diagnostics

### DIFF
--- a/src/languageFeatures.ts
+++ b/src/languageFeatures.ts
@@ -181,6 +181,7 @@ export class DiagnosticsAdapter extends Adapter {
 			}
 			const markers = diagnostics
 				.reduce((p, c) => c.concat(p), [])
+				.filter(d => (this._defaults.getDiagnosticsOptions().diagnosticCodesToIgnore || []).indexOf(d.code) === -1)
 				.map(d => this._convertDiagnostics(resource, d));
 
 			monaco.editor.setModelMarkers(monaco.editor.getModel(resource), this._selector, markers);

--- a/src/monaco.d.ts
+++ b/src/monaco.d.ts
@@ -129,6 +129,7 @@ declare module monaco.languages.typescript {
         noSemanticValidation?: boolean;
         noSyntaxValidation?: boolean;
         noSuggestionDiagnostics?: boolean;
+        diagnosticCodesToIgnore?: number[];
     }
 
     export interface LanguageServiceDefaults {


### PR DESCRIPTION
Adds the property `diagnosticCodesToIgnore` to the interface `DiagnosticsOptions` which allows users to ignore certain diagnostics. A prime example would be `A 'return' statement can only be used within a function body. (1108)` if the editor is used in scripting environments where the actual code is implicitly wrapped in a function.

Fixes https://github.com/microsoft/monaco-editor/issues/1069
Fixes https://github.com/microsoft/monaco-editor/issues/1452

**Example**
```js
monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({
    diagnosticCodesToIgnore: [/*top-level return*/ 1108]
});
```