### PR TITLE
Adopt monaco.MarkerTag API

### DIFF
--- a/src/languageFeatures.ts
+++ b/src/languageFeatures.ts
@@ -200,7 +200,8 @@ export class DiagnosticsAdapter extends Adapter {
 			endLineNumber,
 			endColumn,
 			message: flattenDiagnosticMessageText(diag.messageText, '\n'),
-			code: diag.code.toString()
+			code: diag.code.toString(),
+			tags: diag.reportsUnnecessary ? [monaco.MarkerTag.Unnecessary] : []
 		};
 	}
 


### PR DESCRIPTION
Use the marker tag `monaco.MarkerTag.Unnecessary` if the TypeScript service reports code as unused/unreachable when creating diagnostics. This way the corresponding code is rendered with a lower opacity.

**Note**: Currently this only works if the editor options are updated after editor creation (seems like any option will do); e.g. `editor.updateOptions({ formatOnType: true });`. Otherwise the opacity change is not applied. (See https://github.com/microsoft/monaco-editor/issues/1619) I would consider this as blocked until the issue gets resolved because the `Hint` level diagnostic is not shown anymore when using the tag, even if `showUnused` is disabled completely.

**Example code**
```js
{
    const foo = 1; // foo should be rendered with lower opacity
}
```