### PR TITLE
Provide related information to diagnostics

### DIFF
--- a/src/languageFeatures.ts
+++ b/src/languageFeatures.ts
@@ -200,8 +200,29 @@ export class DiagnosticsAdapter extends Adapter {
 			endLineNumber,
 			endColumn,
 			message: flattenDiagnosticMessageText(diag.messageText, '\n'),
-			code: diag.code.toString()
+			code: diag.code.toString(),
+			relatedInformation: this._convertRelatedInformation(resource, diag.relatedInformation)
 		};
+	}
+
+	private _convertRelatedInformation(resource: Uri, relatedInformation?: ts.DiagnosticRelatedInformation[]): monaco.editor.IRelatedInformation[] {
+		if (relatedInformation === undefined)
+			return undefined;
+
+		return relatedInformation.map(info => {
+			const relatedResource = info.file === undefined ? resource : monaco.Uri.parse(info.file.fileName);
+			const { lineNumber: startLineNumber, column: startColumn } = this._offsetToPosition(relatedResource, info.start);
+			const { lineNumber: endLineNumber, column: endColumn } = this._offsetToPosition(relatedResource, info.start + info.length);
+
+			return {
+				resource: relatedResource,
+				startLineNumber,
+				startColumn,
+				endLineNumber,
+				endColumn,
+				message: flattenDiagnosticMessageText(info.messageText, '\n')
+			};
+		});
 	}
 
 	private _tsDiagnosticCategoryToMarkerSeverity(category: ts.DiagnosticCategory): monaco.MarkerSeverity {


### PR DESCRIPTION
Adds related information to a diagnostic if the TypeScript service reports any. An example would be `Did you forget to use 'await'?` in the following code.

```js
function foo(bar: number) {}

function bar() {
    const baz = Promise.resolve(1);
    foo(baz);
    //  ~~~ Related: Did you forget to use 'await'?
}
```