### PR TITLE
Generate and publish typings for package

### DIFF
--- a/src/tsconfig.esm.json
+++ b/src/tsconfig.esm.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "esnext",
     "moduleResolution": "node",
+    "declaration": true,
     "outDir": "../release/esm",
     "target": "es5",
     "lib": [

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -3,6 +3,7 @@
     "module": "amd",
     "moduleResolution": "node",
     "outDir": "../release/dev",
+    "declaration": true,
     "target": "es5",
     "lib": [
       "dom",


### PR DESCRIPTION
Add `"declaration": true` to the tsconfig files so the package's typings will be generated and published. Fixes https://github.com/microsoft/monaco-editor/issues/1491.

Background for this is that I'm working on a [TypeScript+React live editor](https://github.com/OfficeDev/office-ui-fabric-react/tree/master/packages/tsx-editor) based on Monaco which uses the TypeScript worker to access transpiled code, so I'd like proper typings. I know there's already the handwritten `monaco.d.ts` in the package, but it doesn't work for me for a few reasons:
- It declares a module (`monaco.languages.typescript`) into the global scope rather than being importable
- It has to be updated manually
- It's missing some of the typings I need, including references to TS