### PR TITLE
Removes trailing comma in the tsconfig

### DIFF
--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -12,7 +12,7 @@
       "es2015.iterable",
       "es2015.promise"
     ],
-    "strict": true,
+    "strict": true
   },
   "include": [
     "**/*.ts"


### PR DESCRIPTION
Congrats on getting `strict: true` turned on!

Because TS uses its wn JSON5 parser to read the file, it allows for trailing commas and comments. I was using some generic old JSON tooling to add `"declaration": true` and this trailing comma broke that, so I figure I may as well move this back to plain old JSON.