### PR TITLE
Add types for TypeScriptWorker and missing LanguageServiceDefaults methods

### DIFF
--- a/src/monaco.contribution.ts
+++ b/src/monaco.contribution.ts
@@ -208,11 +208,11 @@ const javascriptDefaults = new LanguageServiceDefaultsImpl(
 	{ allowNonTsExtensions: true, allowJs: true, target: ScriptTarget.Latest },
 	{ noSemanticValidation: true, noSyntaxValidation: false });
 
-function getTypeScriptWorker(): Promise<any> {
+function getTypeScriptWorker(): Promise<(...uris: monaco.Uri[]) => Promise<monaco.languages.typescript.TypeScriptWorker>> {
 	return getMode().then(mode => mode.getTypeScriptWorker());
 }
 
-function getJavaScriptWorker(): Promise<any> {
+function getJavaScriptWorker(): Promise<(...uris: monaco.Uri[]) => Promise<monaco.languages.typescript.TypeScriptWorker>> {
 	return getMode().then(mode => mode.getJavaScriptWorker());
 }
 

--- a/src/monaco.d.ts
+++ b/src/monaco.d.ts
@@ -261,39 +261,6 @@ declare module monaco.languages.typescript {
 
     export interface TypeScriptWorker {
         /**
-         * Get the worker's current compiler settings.
-         */
-        getCompilationSettings(): CompilerOptions;
-
-        /**
-         * Get the names of files and libraries currently registered with the worker.
-         */
-        getScriptFileNames(): string[];
-
-        getScriptVersion(fileName: string): string;
-
-        /**
-         * Get what kind of script the given filename is.
-         * @returns `typescript.ScriptKind`: any = 0, JS = 1, JSX = 2, TS = 3, TSX = 4, external = 5, JSON = 6, deferred = 7
-         */
-        getScriptKind(fileName: string): 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7;
-
-        /**
-         * Always returns an empty string.
-         */
-        getCurrentDirectory(): '';
-
-        /**
-         * Get the name of the default lib file based on `options.target`.
-         */
-        getDefaultLibFileName(options: CompilerOptions): string;
-
-        /**
-         * Returns true if `fileName` matches the default file name for the current compiler options.
-         */
-        isDefaultLibFileName(fileName: string): boolean;
-
-        /**
          * Get diagnostic messages for any syntax issues in the given file.
          */
         getSyntacticDiagnostics(fileName: string): Promise<Diagnostic[]>;

--- a/src/monaco.d.ts
+++ b/src/monaco.d.ts
@@ -377,11 +377,11 @@ declare module monaco.languages.typescript {
         getCodeFixesAtPosition(fileName: string, start: number, end: number, errorCodes: number[], formatOptions: any): Promise<ReadonlyArray<any>>;
     }
 
-    export var typescriptVersion: string;
+    export const typescriptVersion: string;
 
-    export var typescriptDefaults: LanguageServiceDefaults;
-    export var javascriptDefaults: LanguageServiceDefaults;
+    export const typescriptDefaults: LanguageServiceDefaults;
+    export const javascriptDefaults: LanguageServiceDefaults;
 
-    export var getTypeScriptWorker: () => Promise<(first: Uri, ...more: Uri[]) => Promise<TypeScriptWorker>>;
-    export var getJavaScriptWorker: () => Promise<(first: Uri, ...more: Uri[]) => Promise<TypeScriptWorker>>;
+    export const getTypeScriptWorker: () => Promise<(...uris: Uri[]) => Promise<TypeScriptWorker>>;
+    export const getJavaScriptWorker: () => Promise<(...uris: Uri[]) => Promise<TypeScriptWorker>>;
 }

--- a/src/monaco.d.ts
+++ b/src/monaco.d.ts
@@ -146,7 +146,55 @@ declare module monaco.languages.typescript {
         [path: string]: IExtraLib;
     }
 
+    /**
+     * A linked list of formatted diagnostic messages to be used as part of a multiline message.
+     * It is built from the bottom up, leaving the head to be the "main" diagnostic.
+     */
+    interface DiagnosticMessageChain {
+        messageText: string;
+        /** Diagnostic category: warning = 0, error = 1, suggestion = 2, message = 3 */
+        category: 0 | 1 | 2 | 3;
+        code: number;
+        next?: DiagnosticMessageChain[];
+    }
+    interface Diagnostic extends DiagnosticRelatedInformation {
+        /** May store more in future. For now, this will simply be `true` to indicate when a diagnostic is an unused-identifier diagnostic. */
+        reportsUnnecessary?: {};
+        source?: string;
+        relatedInformation?: DiagnosticRelatedInformation[];
+    }
+    interface DiagnosticRelatedInformation {
+        /** Diagnostic category: warning = 0, error = 1, suggestion = 2, message = 3 */
+        category: 0 | 1 | 2 | 3;
+        code: number;
+        /** TypeScriptWorker removes this to avoid serializing circular JSON structures. */
+        file: undefined;
+        start: number | undefined;
+        length: number | undefined;
+        messageText: string | DiagnosticMessageChain;
+    }
+
+    interface EmitOutput {
+        outputFiles: OutputFile[];
+        emitSkipped: boolean;
+    }
+    interface OutputFile {
+        name: string;
+        writeByteOrderMark: boolean;
+        text: string;
+    }
+
     export interface LanguageServiceDefaults {
+        /**
+         * Event fired when compiler options or diagnostics options are changed.
+         */
+        readonly onDidChange: IEvent<void>;
+
+        /**
+         * Event fired when extra libraries registered with the language service change.
+         */
+        readonly onDidExtraLibsChange: IEvent<void>;
+
         /**
          * Get the current extra libs registered with the language service.
          */
@@ -212,33 +260,154 @@ declare module monaco.languages.typescript {
     }
 
     export interface TypeScriptWorker {
+        /**
+         * Get the worker's current compiler settings.
+         */
         getCompilationSettings(): CompilerOptions;
+
+        /**
+         * Get the names of files and libraries currently registered with the worker.
+         */
         getScriptFileNames(): string[];
+
         getScriptVersion(fileName: string): string;
-        getScriptKind(fileName: string): ts.ScriptKind;
-        getCurrentDirectory(): string;
+
+        /**
+         * Get what kind of script the given filename is.
+         * @returns `typescript.ScriptKind`: any = 0, JS = 1, JSX = 2, TS = 3, TSX = 4, external = 5, JSON = 6, deferred = 7
+         */
+        getScriptKind(fileName: string): 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7;
+
+        /**
+         * Always returns an empty string.
+         */
+        getCurrentDirectory(): '';
+
+        /**
+         * Get the name of the default lib file based on `options.target`.
+         */
         getDefaultLibFileName(options: CompilerOptions): string;
+
+        /**
+         * Returns true if `fileName` matches the default file name for the current compiler options.
+         */
         isDefaultLibFileName(fileName: string): boolean;
-        getSyntacticDiagnostics(fileName: string): Promise<ts.Diagnostic[]>;
-        getSemanticDiagnostics(fileName: string): Promise<ts.Diagnostic[]>;
-        getSuggestionDiagnostics(fileName: string): Promise<ts.DiagnosticWithLocation[]>;
-        getCompilerOptionsDiagnostics(fileName: string): Promise<ts.Diagnostic[]>;
-        getCompletionsAtPosition(fileName: string, position: number): Promise<ts.CompletionInfo | undefined>;
-        getCompletionEntryDetails(fileName: string, position: number, entry: string): Promise<ts.CompletionEntryDetails | undefined>;
-        getSignatureHelpItems(fileName: string, position: number): Promise<ts.SignatureHelpItems | undefined>;
-        getQuickInfoAtPosition(fileName: string, position: number): Promise<ts.QuickInfo | undefined>;
-        getOccurrencesAtPosition(fileName: string, position: number): Promise<ReadonlyArray<ts.ReferenceEntry> | undefined>;
-        getDefinitionAtPosition(fileName: string, position: number): Promise<ReadonlyArray<ts.DefinitionInfo> | undefined>;
-        getReferencesAtPosition(fileName: string, position: number): Promise<ts.ReferenceEntry[] | undefined>;
-        getNavigationBarItems(fileName: string): Promise<ts.NavigationBarItem[]>;
-        getFormattingEditsForDocument(fileName: string, options: ts.FormatCodeOptions): Promise<ts.TextChange[]>;
-        getFormattingEditsForRange(fileName: string, start: number, end: number, options: ts.FormatCodeOptions): Promise<ts.TextChange[]>;
-        getFormattingEditsAfterKeystroke(fileName: string, postion: number, ch: string, options: ts.FormatCodeOptions): Promise<ts.TextChange[]>;
-        findRenameLocations(fileName: string, positon: number, findInStrings: boolean, findInComments: boolean, providePrefixAndSuffixTextForRename: boolean): Promise<readonly ts.RenameLocation[] | undefined>;
-        getRenameInfo(fileName: string, positon: number, options: ts.RenameInfoOptions): Promise<ts.RenameInfo>;
-        getEmitOutput(fileName: string): Promise<ts.EmitOutput>;
-        getCodeFixesAtPosition(fileName: string, start: number, end: number, errorCodes: number[], formatOptions: ts.FormatCodeOptions): Promise<ReadonlyArray<ts.CodeFixAction>>;
-        updateExtraLibs(extraLibs: IExtraLibs): void;
+
+        /**
+         * Get diagnostic messages for any syntax issues in the given file.
+         */
+        getSyntacticDiagnostics(fileName: string): Promise<Diagnostic[]>;
+
+        /**
+         * Get diagnostic messages for any semantic issues in the given file.
+         */
+        getSemanticDiagnostics(fileName: string): Promise<Diagnostic[]>;
+
+        /**
+         * Get diagnostic messages for any suggestions related to the given file.
+         */
+        getSuggestionDiagnostics(fileName: string): Promise<Diagnostic[]>;
+
+        /**
+         * Get diagnostic messages related to the current compiler options.
+         * @param fileName Not used
+         */
+        getCompilerOptionsDiagnostics(fileName: string): Promise<Diagnostic[]>;
+
+        /**
+         * Get code completions for the given file and position.
+         * @returns `Promise<typescript.CompletionInfo | undefined>`
+         */
+        getCompletionsAtPosition(fileName: string, position: number): Promise<any | undefined>;
+
+        /**
+         * Get code completion details for the given file, position, and entry.
+         * @returns `Promise<typescript.CompletionEntryDetails | undefined>`
+         */
+        getCompletionEntryDetails(fileName: string, position: number, entry: string): Promise<any | undefined>;
+
+        /**
+         * Get signature help items for the item at the given file and position.
+         * @returns `Promise<typescript.SignatureHelpItems | undefined>`
+         */
+        getSignatureHelpItems(fileName: string, position: number): Promise<any | undefined>;
+
+        /**
+         * Get quick info for the item at the given position in the file.
+         * @returns `Promise<typescript.QuickInfo | undefined>`
+         */
+        getQuickInfoAtPosition(fileName: string, position: number): Promise<any | undefined>;
+
+        /**
+         * Get other ranges which are related to the item at the given position in the file (often used for highlighting).
+         * @returns `Promise<ReadonlyArray<typescript.ReferenceEntry> | undefined>`
+         */
+        getOccurrencesAtPosition(fileName: string, position: number): Promise<ReadonlyArray<any> | undefined>;
+
+        /**
+         * Get the definition of the item at the given position in the file.
+         * @returns `Promise<ReadonlyArray<typescript.DefinitionInfo> | undefined>`
+         */
+        getDefinitionAtPosition(fileName: string, position: number): Promise<ReadonlyArray<any> | undefined>;
+
+        /**
+         * Get references to the item at the given position in the file.
+         * @returns `Promise<typescript.ReferenceEntry[] | undefined>`
+         */
+        getReferencesAtPosition(fileName: string, position: number): Promise<any[] | undefined>;
+
+        /**
+         * Get outline entries for the item at the given position in the file.
+         * @returns `Promise<typescript.NavigationBarItem[]>`
+         */
+        getNavigationBarItems(fileName: string): Promise<any[]>;
+
+        /**
+         * Get changes which should be applied to format the given file.
+         * @param options `typescript.FormatCodeOptions`
+         * @returns `Promise<typescript.TextChange[]>`
+         */
+        getFormattingEditsForDocument(fileName: string, options: any): Promise<any[]>;
+
+        /**
+         * Get changes which should be applied to format the given range in the file.
+         * @param options `typescript.FormatCodeOptions`
+         * @returns `Promise<typescript.TextChange[]>`
+         */
+        getFormattingEditsForRange(fileName: string, start: number, end: number, options: any): Promise<any[]>;
+
+        /**
+         * Get formatting changes which should be applied after the given keystroke.
+         * @param options `typescript.FormatCodeOptions`
+         * @returns `Promise<typescript.TextChange[]>`
+         */
+        getFormattingEditsAfterKeystroke(fileName: string, postion: number, ch: string, options: any): Promise<any[]>;
+
+        /**
+         * Get other occurrences which should be updated when renaming the item at the given file and position.
+         * @returns `Promise<readonly typescript.RenameLocation[] | undefined>`
+         */
+        findRenameLocations(fileName: string, positon: number, findInStrings: boolean, findInComments: boolean, providePrefixAndSuffixTextForRename: boolean): Promise<readonly any[] | undefined>;
+
+        /**
+         * Get edits which should be applied to rename the item at the given file and position (or a failure reason).
+         * @param options `typescript.RenameInfoOptions`
+         * @returns `Promise<typescript.RenameInfo>`
+         */
+        getRenameInfo(fileName: string, positon: number, options: any): Promise<any>;
+
+        /**
+         * Get transpiled output for the given file.
+         * @returns `typescript.EmitOutput`
+         */
+        getEmitOutput(fileName: string): Promise<any>;
+
+        /**
+         * Get possible code fixes at the given position in the file.
+         * @param formatOptions `typescript.FormatCodeOptions`
+         * @returns `Promise<ReadonlyArray<typescript.CodeFixAction>>`
+         */
+        getCodeFixesAtPosition(fileName: string, start: number, end: number, errorCodes: number[], formatOptions: any): Promise<ReadonlyArray<any>>;
     }
 
     export var typescriptVersion: string;
@@ -248,365 +417,4 @@ declare module monaco.languages.typescript {
 
     export var getTypeScriptWorker: () => Promise<(first: Uri, ...more: Uri[]) => Promise<TypeScriptWorker>>;
     export var getJavaScriptWorker: () => Promise<(first: Uri, ...more: Uri[]) => Promise<TypeScriptWorker>>;
-}
-
-/**
- * Additional types copied from `typescript`.
- */
-declare module monaco.languages.typescript.ts {
-    /**
-     * A linked list of formatted diagnostic messages to be used as part of a multiline message.
-     * It is built from the bottom up, leaving the head to be the "main" diagnostic.
-     */
-    interface DiagnosticMessageChain {
-        messageText: string;
-        category: DiagnosticCategory;
-        code: number;
-        next?: DiagnosticMessageChain[];
-    }
-    interface Diagnostic extends DiagnosticRelatedInformation {
-        /** May store more in future. For now, this will simply be `true` to indicate when a diagnostic is an unused-identifier diagnostic. */
-        reportsUnnecessary?: {};
-        source?: string;
-        relatedInformation?: DiagnosticRelatedInformation[];
-    }
-    interface DiagnosticRelatedInformation {
-        category: DiagnosticCategory;
-        code: number;
-        /** TypeScriptWorker removes this to avoid serializing circular JSON structures. */
-        file: undefined;
-        start: number | undefined;
-        length: number | undefined;
-        messageText: string | DiagnosticMessageChain;
-    }
-    interface DiagnosticWithLocation extends Diagnostic {
-        /** TypeScriptWorker removes this to avoid serializing circular JSON structures. */
-        file: undefined;
-        start: number;
-        length: number;
-    }
-    // Must be a const enum because this module doesn't exist at runtime
-    const enum DiagnosticCategory {
-        Warning = 0,
-        Error = 1,
-        Suggestion = 2,
-        Message = 3
-    }
-    // Must be a const enum because this module doesn't exist at runtime
-    const enum ScriptKind {
-        Unknown = 0,
-        JS = 1,
-        JSX = 2,
-        TS = 3,
-        TSX = 4,
-        External = 5,
-        JSON = 6,
-        /**
-         * Used on extensions that doesn't define the ScriptKind but the content defines it.
-         * Deferred extensions are going to be included in all project contexts.
-         */
-        Deferred = 7
-    }
-    interface TextSpan {
-        start: number;
-        length: number;
-    }
-
-    interface EmitOutput {
-        outputFiles: OutputFile[];
-        emitSkipped: boolean;
-    }
-    interface OutputFile {
-        name: string;
-        writeByteOrderMark: boolean;
-        text: string;
-    }
-
-    /**
-     * Navigation bar interface designed for visual studio's dual-column layout.
-     * This does not form a proper tree.
-     * The navbar is returned as a list of top-level items, each of which has a list of child items.
-     * Child items always have an empty array for their `childItems`.
-     */
-    interface NavigationBarItem {
-        text: string;
-        kind: ScriptElementKind;
-        kindModifiers: string;
-        spans: TextSpan[];
-        childItems: NavigationBarItem[];
-        indent: number;
-        bolded: boolean;
-        grayed: boolean;
-    }
-    interface TextChange {
-        span: TextSpan;
-        newText: string;
-    }
-    interface FileTextChanges {
-        fileName: string;
-        textChanges: readonly TextChange[];
-        isNewFile?: boolean;
-    }
-    interface CodeAction {
-        /** Description of the code action to display in the UI of the editor */
-        description: string;
-        /** Text changes to apply to each file as part of the code action */
-        changes: FileTextChanges[];
-        /**
-         * If the user accepts the code fix, the editor should send the action back in a `applyAction` request.
-         * This allows the language service to have side effects (e.g. installing dependencies) upon a code fix.
-         */
-        commands?: CodeActionCommand[];
-    }
-    interface CodeFixAction extends CodeAction {
-        /** Short name to identify the fix, for use by telemetry. */
-        fixName: string;
-        /**
-         * If present, one may call 'getCombinedCodeFix' with this fixId.
-         * This may be omitted to indicate that the code fix can't be applied in a group.
-         */
-        fixId?: {};
-        fixAllDescription?: string;
-    }
-    type CodeActionCommand = InstallPackageAction;
-    interface InstallPackageAction {
-    }
-    interface DocumentSpan {
-        textSpan: TextSpan;
-        fileName: string;
-        /**
-         * If the span represents a location that was remapped (e.g. via a .d.ts.map file),
-         * then the original filename and span will be specified here
-         */
-        originalTextSpan?: TextSpan;
-        originalFileName?: string;
-        /**
-         * If DocumentSpan.textSpan is the span for name of the declaration,
-         * then this is the span for relevant declaration
-         */
-        contextSpan?: TextSpan;
-        originalContextSpan?: TextSpan;
-    }
-    interface RenameLocation extends DocumentSpan {
-        readonly prefixText?: string;
-        readonly suffixText?: string;
-    }
-    interface ReferenceEntry extends DocumentSpan {
-        isWriteAccess: boolean;
-        isDefinition: boolean;
-        isInString?: true;
-    }
-    // Must be a const enum because this module doesn't exist at runtime
-    const enum IndentStyle {
-        None = 0,
-        Block = 1,
-        Smart = 2
-    }
-    interface EditorOptions {
-        BaseIndentSize?: number;
-        IndentSize: number;
-        TabSize: number;
-        NewLineCharacter: string;
-        ConvertTabsToSpaces: boolean;
-        IndentStyle: IndentStyle;
-    }
-    interface FormatCodeOptions extends EditorOptions {
-        InsertSpaceAfterCommaDelimiter: boolean;
-        InsertSpaceAfterSemicolonInForStatements: boolean;
-        InsertSpaceBeforeAndAfterBinaryOperators: boolean;
-        InsertSpaceAfterConstructor?: boolean;
-        InsertSpaceAfterKeywordsInControlFlowStatements: boolean;
-        InsertSpaceAfterFunctionKeywordForAnonymousFunctions: boolean;
-        InsertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis: boolean;
-        InsertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets: boolean;
-        InsertSpaceAfterOpeningAndBeforeClosingNonemptyBraces?: boolean;
-        InsertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces: boolean;
-        InsertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces?: boolean;
-        InsertSpaceAfterTypeAssertion?: boolean;
-        InsertSpaceBeforeFunctionParenthesis?: boolean;
-        PlaceOpenBraceOnNewLineForFunctions: boolean;
-        PlaceOpenBraceOnNewLineForControlBlocks: boolean;
-        insertSpaceBeforeTypeAnnotation?: boolean;
-    }
-    interface DefinitionInfo extends DocumentSpan {
-        kind: ScriptElementKind;
-        name: string;
-        containerKind: ScriptElementKind;
-        containerName: string;
-    }
-    interface SymbolDisplayPart {
-        text: string;
-        kind: string;
-    }
-    interface JSDocTagInfo {
-        name: string;
-        text?: string;
-    }
-    interface QuickInfo {
-        kind: ScriptElementKind;
-        kindModifiers: string;
-        textSpan: TextSpan;
-        displayParts?: SymbolDisplayPart[];
-        documentation?: SymbolDisplayPart[];
-        tags?: JSDocTagInfo[];
-    }
-    type RenameInfo = RenameInfoSuccess | RenameInfoFailure;
-    interface RenameInfoSuccess {
-        canRename: true;
-        /**
-         * File or directory to rename.
-         * If set, `getEditsForFileRename` should be called instead of `findRenameLocations`.
-         */
-        fileToRename?: string;
-        displayName: string;
-        fullDisplayName: string;
-        kind: ScriptElementKind;
-        kindModifiers: string;
-        triggerSpan: TextSpan;
-    }
-    interface RenameInfoFailure {
-        canRename: false;
-        localizedErrorMessage: string;
-    }
-    interface RenameInfoOptions {
-        readonly allowRenameOfImportPath?: boolean;
-    }
-    interface SignatureHelpParameter {
-        name: string;
-        documentation: SymbolDisplayPart[];
-        displayParts: SymbolDisplayPart[];
-        isOptional: boolean;
-    }
-    /**
-     * Represents a single signature to show in signature help.
-     * The id is used for subsequent calls into the language service to ask questions about the
-     * signature help item in the context of any documents that have been updated.  i.e. after
-     * an edit has happened, while signature help is still active, the host can ask important
-     * questions like 'what parameter is the user currently contained within?'.
-     */
-    interface SignatureHelpItem {
-        isVariadic: boolean;
-        prefixDisplayParts: SymbolDisplayPart[];
-        suffixDisplayParts: SymbolDisplayPart[];
-        separatorDisplayParts: SymbolDisplayPart[];
-        parameters: SignatureHelpParameter[];
-        documentation: SymbolDisplayPart[];
-        tags: JSDocTagInfo[];
-    }
-    /**
-     * Represents a set of signature help items, and the preferred item that should be selected.
-     */
-    interface SignatureHelpItems {
-        items: SignatureHelpItem[];
-        applicableSpan: TextSpan;
-        selectedItemIndex: number;
-        argumentIndex: number;
-        argumentCount: number;
-    }
-    interface CompletionInfo {
-        /** Not true for all global completions. This will be true if the enclosing scope matches a few syntax kinds. See `isSnippetScope`. */
-        isGlobalCompletion: boolean;
-        isMemberCompletion: boolean;
-        /**
-         * true when the current location also allows for a new identifier
-         */
-        isNewIdentifierLocation: boolean;
-        entries: CompletionEntry[];
-    }
-    interface CompletionEntry {
-        name: string;
-        kind: ScriptElementKind;
-        kindModifiers?: string;
-        sortText: string;
-        insertText?: string;
-        /**
-         * An optional span that indicates the text to be replaced by this completion item.
-         * If present, this span should be used instead of the default one.
-         * It will be set if the required span differs from the one generated by the default replacement behavior.
-         */
-        replacementSpan?: TextSpan;
-        hasAction?: true;
-        source?: string;
-        isRecommended?: true;
-    }
-    interface CompletionEntryDetails {
-        name: string;
-        kind: ScriptElementKind;
-        kindModifiers: string;
-        displayParts: SymbolDisplayPart[];
-        documentation?: SymbolDisplayPart[];
-        tags?: JSDocTagInfo[];
-        codeActions?: CodeAction[];
-        source?: SymbolDisplayPart[];
-    }
-    // Must be a const enum because this module doesn't exist at runtime
-    const enum ScriptElementKind {
-        unknown = "",
-        warning = "warning",
-        /** predefined type (void) or keyword (class) */
-        keyword = "keyword",
-        /** top level script node */
-        scriptElement = "script",
-        /** module foo {} */
-        moduleElement = "module",
-        /** class X {} */
-        classElement = "class",
-        /** var x = class X {} */
-        localClassElement = "local class",
-        /** interface Y {} */
-        interfaceElement = "interface",
-        /** type T = ... */
-        typeElement = "type",
-        /** enum E */
-        enumElement = "enum",
-        enumMemberElement = "enum member",
-        /**
-         * Inside module and script only
-         * const v = ..
-         */
-        variableElement = "var",
-        /** Inside function */
-        localVariableElement = "local var",
-        /**
-         * Inside module and script only
-         * function f() { }
-         */
-        functionElement = "function",
-        /** Inside function */
-        localFunctionElement = "local function",
-        /** class X { [public|private]* foo() {} } */
-        memberFunctionElement = "method",
-        /** class X { [public|private]* [get|set] foo:number; } */
-        memberGetAccessorElement = "getter",
-        memberSetAccessorElement = "setter",
-        /**
-         * class X { [public|private]* foo:number; }
-         * interface Y { foo:number; }
-         */
-        memberVariableElement = "property",
-        /** class X { constructor() { } } */
-        constructorImplementationElement = "constructor",
-        /** interface Y { ():number; } */
-        callSignatureElement = "call",
-        /** interface Y { []:number; } */
-        indexSignatureElement = "index",
-        /** interface Y { new():Y; } */
-        constructSignatureElement = "construct",
-        /** function foo(*Y*: string) */
-        parameterElement = "parameter",
-        typeParameterElement = "type parameter",
-        primitiveType = "primitive type",
-        label = "label",
-        alias = "alias",
-        constElement = "const",
-        letElement = "let",
-        directory = "directory",
-        externalModuleName = "external module name",
-        /**
-         * <JsxTagName attribute1 attribute2={0} />
-         */
-        jsxAttribute = "JSX attribute",
-        /** String literal */
-        string = "string"
-    }
 }

--- a/src/monaco.d.ts
+++ b/src/monaco.d.ts
@@ -49,6 +49,7 @@ declare module monaco.languages.typescript {
     interface CompilerOptions {
         allowJs?: boolean;
         allowSyntheticDefaultImports?: boolean;
+        allowUmdGlobalAccess?: boolean;
         allowUnreachableCode?: boolean;
         allowUnusedLabels?: boolean;
         alwaysStrict?: boolean;
@@ -60,6 +61,7 @@ declare module monaco.languages.typescript {
         emitDeclarationOnly?: boolean;
         declarationDir?: string;
         disableSizeLimit?: boolean;
+        disableSourceOfProjectReferenceRedirect?: boolean;
         downlevelIteration?: boolean;
         emitBOM?: boolean;
         emitDecoratorMetadata?: boolean;
@@ -111,8 +113,10 @@ declare module monaco.languages.typescript {
         sourceRoot?: string;
         strict?: boolean;
         strictFunctionTypes?: boolean;
+        strictBindCallApply?: boolean;
         strictNullChecks?: boolean;
         strictPropertyInitialization?: boolean;
+        stripInternal?: boolean;
         suppressExcessPropertyErrors?: boolean;
         suppressImplicitAnyIndexErrors?: boolean;
         target?: ScriptTarget;
@@ -122,6 +126,7 @@ declare module monaco.languages.typescript {
         /** Paths used to compute primary types search locations */
         typeRoots?: string[];
         esModuleInterop?: boolean;
+        useDefineForClassFields?: boolean;
         [option: string]: CompilerOptionsValue | undefined;
     }
 
@@ -132,7 +137,21 @@ declare module monaco.languages.typescript {
         diagnosticCodesToIgnore?: number[];
     }
 
+    interface IExtraLib {
+        content: string;
+        version: number;
+    }
+
+    interface IExtraLibs {
+        [path: string]: IExtraLib;
+    }
+
     export interface LanguageServiceDefaults {
+        /**
+         * Get the current extra libs registered with the language service.
+         */
+        getExtraLibs(): IExtraLibs;
+
         /**
          * Add an additional source file to the language service. Use this
          * for typescript (definition) files that won't be loaded as editor
@@ -154,9 +173,19 @@ declare module monaco.languages.typescript {
         setExtraLibs(libs: { content: string; filePath?: string }[]): void;
 
         /**
+         * Get current TypeScript compiler options for the language service.
+         */
+        getCompilerOptions(): CompilerOptions;
+
+        /**
          * Set TypeScript compiler options.
          */
         setCompilerOptions(options: CompilerOptions): void;
+
+        /**
+         * Get the current diagnostics options for the language service.
+         */
+        getDiagnosticsOptions(): DiagnosticsOptions;
 
         /**
          * Configure whether syntactic and/or semantic validation should
@@ -165,10 +194,7 @@ declare module monaco.languages.typescript {
         setDiagnosticsOptions(options: DiagnosticsOptions): void;
 
         /**
-         * Configure when the worker shuts down. By default that is 2mins.
-         *
-         * @param value The maximum idle time in milliseconds. Values less than one
-         * mean never shut down.
+         * No-op.
          */
         setMaximumWorkerIdleTime(value: number): void;
 
@@ -177,6 +203,42 @@ declare module monaco.languages.typescript {
          * to the worker on start or restart.
          */
         setEagerModelSync(value: boolean): void;
+
+        /**
+         * Get the current setting for whether all existing models should be eagerly sync'd
+         * to the worker on start or restart.
+         */
+        getEagerModelSync(): boolean;
+    }
+
+    export interface TypeScriptWorker {
+        getCompilationSettings(): CompilerOptions;
+        getScriptFileNames(): string[];
+        getScriptVersion(fileName: string): string;
+        getScriptKind(fileName: string): ts.ScriptKind;
+        getCurrentDirectory(): string;
+        getDefaultLibFileName(options: CompilerOptions): string;
+        isDefaultLibFileName(fileName: string): boolean;
+        getSyntacticDiagnostics(fileName: string): Promise<ts.Diagnostic[]>;
+        getSemanticDiagnostics(fileName: string): Promise<ts.Diagnostic[]>;
+        getSuggestionDiagnostics(fileName: string): Promise<ts.DiagnosticWithLocation[]>;
+        getCompilerOptionsDiagnostics(fileName: string): Promise<ts.Diagnostic[]>;
+        getCompletionsAtPosition(fileName: string, position: number): Promise<ts.CompletionInfo | undefined>;
+        getCompletionEntryDetails(fileName: string, position: number, entry: string): Promise<ts.CompletionEntryDetails | undefined>;
+        getSignatureHelpItems(fileName: string, position: number): Promise<ts.SignatureHelpItems | undefined>;
+        getQuickInfoAtPosition(fileName: string, position: number): Promise<ts.QuickInfo | undefined>;
+        getOccurrencesAtPosition(fileName: string, position: number): Promise<ReadonlyArray<ts.ReferenceEntry> | undefined>;
+        getDefinitionAtPosition(fileName: string, position: number): Promise<ReadonlyArray<ts.DefinitionInfo> | undefined>;
+        getReferencesAtPosition(fileName: string, position: number): Promise<ts.ReferenceEntry[] | undefined>;
+        getNavigationBarItems(fileName: string): Promise<ts.NavigationBarItem[]>;
+        getFormattingEditsForDocument(fileName: string, options: ts.FormatCodeOptions): Promise<ts.TextChange[]>;
+        getFormattingEditsForRange(fileName: string, start: number, end: number, options: ts.FormatCodeOptions): Promise<ts.TextChange[]>;
+        getFormattingEditsAfterKeystroke(fileName: string, postion: number, ch: string, options: ts.FormatCodeOptions): Promise<ts.TextChange[]>;
+        findRenameLocations(fileName: string, positon: number, findInStrings: boolean, findInComments: boolean, providePrefixAndSuffixTextForRename: boolean): Promise<readonly ts.RenameLocation[] | undefined>;
+        getRenameInfo(fileName: string, positon: number, options: ts.RenameInfoOptions): Promise<ts.RenameInfo>;
+        getEmitOutput(fileName: string): Promise<ts.EmitOutput>;
+        getCodeFixesAtPosition(fileName: string, start: number, end: number, errorCodes: number[], formatOptions: ts.FormatCodeOptions): Promise<ReadonlyArray<ts.CodeFixAction>>;
+        updateExtraLibs(extraLibs: IExtraLibs): void;
     }
 
     export var typescriptVersion: string;
@@ -184,6 +246,367 @@ declare module monaco.languages.typescript {
     export var typescriptDefaults: LanguageServiceDefaults;
     export var javascriptDefaults: LanguageServiceDefaults;
 
-    export var getTypeScriptWorker: () => Promise<any>;
-    export var getJavaScriptWorker: () => Promise<any>;
+    export var getTypeScriptWorker: () => Promise<(first: Uri, ...more: Uri[]) => Promise<TypeScriptWorker>>;
+    export var getJavaScriptWorker: () => Promise<(first: Uri, ...more: Uri[]) => Promise<TypeScriptWorker>>;
+}
+
+/**
+ * Additional types copied from `typescript`.
+ */
+declare module monaco.languages.typescript.ts {
+    /**
+     * A linked list of formatted diagnostic messages to be used as part of a multiline message.
+     * It is built from the bottom up, leaving the head to be the "main" diagnostic.
+     */
+    interface DiagnosticMessageChain {
+        messageText: string;
+        category: DiagnosticCategory;
+        code: number;
+        next?: DiagnosticMessageChain[];
+    }
+    interface Diagnostic extends DiagnosticRelatedInformation {
+        /** May store more in future. For now, this will simply be `true` to indicate when a diagnostic is an unused-identifier diagnostic. */
+        reportsUnnecessary?: {};
+        source?: string;
+        relatedInformation?: DiagnosticRelatedInformation[];
+    }
+    interface DiagnosticRelatedInformation {
+        category: DiagnosticCategory;
+        code: number;
+        /** TypeScriptWorker removes this to avoid serializing circular JSON structures. */
+        file: undefined;
+        start: number | undefined;
+        length: number | undefined;
+        messageText: string | DiagnosticMessageChain;
+    }
+    interface DiagnosticWithLocation extends Diagnostic {
+        /** TypeScriptWorker removes this to avoid serializing circular JSON structures. */
+        file: undefined;
+        start: number;
+        length: number;
+    }
+    // Must be a const enum because this module doesn't exist at runtime
+    const enum DiagnosticCategory {
+        Warning = 0,
+        Error = 1,
+        Suggestion = 2,
+        Message = 3
+    }
+    // Must be a const enum because this module doesn't exist at runtime
+    const enum ScriptKind {
+        Unknown = 0,
+        JS = 1,
+        JSX = 2,
+        TS = 3,
+        TSX = 4,
+        External = 5,
+        JSON = 6,
+        /**
+         * Used on extensions that doesn't define the ScriptKind but the content defines it.
+         * Deferred extensions are going to be included in all project contexts.
+         */
+        Deferred = 7
+    }
+    interface TextSpan {
+        start: number;
+        length: number;
+    }
+
+    interface EmitOutput {
+        outputFiles: OutputFile[];
+        emitSkipped: boolean;
+    }
+    interface OutputFile {
+        name: string;
+        writeByteOrderMark: boolean;
+        text: string;
+    }
+
+    /**
+     * Navigation bar interface designed for visual studio's dual-column layout.
+     * This does not form a proper tree.
+     * The navbar is returned as a list of top-level items, each of which has a list of child items.
+     * Child items always have an empty array for their `childItems`.
+     */
+    interface NavigationBarItem {
+        text: string;
+        kind: ScriptElementKind;
+        kindModifiers: string;
+        spans: TextSpan[];
+        childItems: NavigationBarItem[];
+        indent: number;
+        bolded: boolean;
+        grayed: boolean;
+    }
+    interface TextChange {
+        span: TextSpan;
+        newText: string;
+    }
+    interface FileTextChanges {
+        fileName: string;
+        textChanges: readonly TextChange[];
+        isNewFile?: boolean;
+    }
+    interface CodeAction {
+        /** Description of the code action to display in the UI of the editor */
+        description: string;
+        /** Text changes to apply to each file as part of the code action */
+        changes: FileTextChanges[];
+        /**
+         * If the user accepts the code fix, the editor should send the action back in a `applyAction` request.
+         * This allows the language service to have side effects (e.g. installing dependencies) upon a code fix.
+         */
+        commands?: CodeActionCommand[];
+    }
+    interface CodeFixAction extends CodeAction {
+        /** Short name to identify the fix, for use by telemetry. */
+        fixName: string;
+        /**
+         * If present, one may call 'getCombinedCodeFix' with this fixId.
+         * This may be omitted to indicate that the code fix can't be applied in a group.
+         */
+        fixId?: {};
+        fixAllDescription?: string;
+    }
+    type CodeActionCommand = InstallPackageAction;
+    interface InstallPackageAction {
+    }
+    interface DocumentSpan {
+        textSpan: TextSpan;
+        fileName: string;
+        /**
+         * If the span represents a location that was remapped (e.g. via a .d.ts.map file),
+         * then the original filename and span will be specified here
+         */
+        originalTextSpan?: TextSpan;
+        originalFileName?: string;
+        /**
+         * If DocumentSpan.textSpan is the span for name of the declaration,
+         * then this is the span for relevant declaration
+         */
+        contextSpan?: TextSpan;
+        originalContextSpan?: TextSpan;
+    }
+    interface RenameLocation extends DocumentSpan {
+        readonly prefixText?: string;
+        readonly suffixText?: string;
+    }
+    interface ReferenceEntry extends DocumentSpan {
+        isWriteAccess: boolean;
+        isDefinition: boolean;
+        isInString?: true;
+    }
+    // Must be a const enum because this module doesn't exist at runtime
+    const enum IndentStyle {
+        None = 0,
+        Block = 1,
+        Smart = 2
+    }
+    interface EditorOptions {
+        BaseIndentSize?: number;
+        IndentSize: number;
+        TabSize: number;
+        NewLineCharacter: string;
+        ConvertTabsToSpaces: boolean;
+        IndentStyle: IndentStyle;
+    }
+    interface FormatCodeOptions extends EditorOptions {
+        InsertSpaceAfterCommaDelimiter: boolean;
+        InsertSpaceAfterSemicolonInForStatements: boolean;
+        InsertSpaceBeforeAndAfterBinaryOperators: boolean;
+        InsertSpaceAfterConstructor?: boolean;
+        InsertSpaceAfterKeywordsInControlFlowStatements: boolean;
+        InsertSpaceAfterFunctionKeywordForAnonymousFunctions: boolean;
+        InsertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis: boolean;
+        InsertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets: boolean;
+        InsertSpaceAfterOpeningAndBeforeClosingNonemptyBraces?: boolean;
+        InsertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces: boolean;
+        InsertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces?: boolean;
+        InsertSpaceAfterTypeAssertion?: boolean;
+        InsertSpaceBeforeFunctionParenthesis?: boolean;
+        PlaceOpenBraceOnNewLineForFunctions: boolean;
+        PlaceOpenBraceOnNewLineForControlBlocks: boolean;
+        insertSpaceBeforeTypeAnnotation?: boolean;
+    }
+    interface DefinitionInfo extends DocumentSpan {
+        kind: ScriptElementKind;
+        name: string;
+        containerKind: ScriptElementKind;
+        containerName: string;
+    }
+    interface SymbolDisplayPart {
+        text: string;
+        kind: string;
+    }
+    interface JSDocTagInfo {
+        name: string;
+        text?: string;
+    }
+    interface QuickInfo {
+        kind: ScriptElementKind;
+        kindModifiers: string;
+        textSpan: TextSpan;
+        displayParts?: SymbolDisplayPart[];
+        documentation?: SymbolDisplayPart[];
+        tags?: JSDocTagInfo[];
+    }
+    type RenameInfo = RenameInfoSuccess | RenameInfoFailure;
+    interface RenameInfoSuccess {
+        canRename: true;
+        /**
+         * File or directory to rename.
+         * If set, `getEditsForFileRename` should be called instead of `findRenameLocations`.
+         */
+        fileToRename?: string;
+        displayName: string;
+        fullDisplayName: string;
+        kind: ScriptElementKind;
+        kindModifiers: string;
+        triggerSpan: TextSpan;
+    }
+    interface RenameInfoFailure {
+        canRename: false;
+        localizedErrorMessage: string;
+    }
+    interface RenameInfoOptions {
+        readonly allowRenameOfImportPath?: boolean;
+    }
+    interface SignatureHelpParameter {
+        name: string;
+        documentation: SymbolDisplayPart[];
+        displayParts: SymbolDisplayPart[];
+        isOptional: boolean;
+    }
+    /**
+     * Represents a single signature to show in signature help.
+     * The id is used for subsequent calls into the language service to ask questions about the
+     * signature help item in the context of any documents that have been updated.  i.e. after
+     * an edit has happened, while signature help is still active, the host can ask important
+     * questions like 'what parameter is the user currently contained within?'.
+     */
+    interface SignatureHelpItem {
+        isVariadic: boolean;
+        prefixDisplayParts: SymbolDisplayPart[];
+        suffixDisplayParts: SymbolDisplayPart[];
+        separatorDisplayParts: SymbolDisplayPart[];
+        parameters: SignatureHelpParameter[];
+        documentation: SymbolDisplayPart[];
+        tags: JSDocTagInfo[];
+    }
+    /**
+     * Represents a set of signature help items, and the preferred item that should be selected.
+     */
+    interface SignatureHelpItems {
+        items: SignatureHelpItem[];
+        applicableSpan: TextSpan;
+        selectedItemIndex: number;
+        argumentIndex: number;
+        argumentCount: number;
+    }
+    interface CompletionInfo {
+        /** Not true for all global completions. This will be true if the enclosing scope matches a few syntax kinds. See `isSnippetScope`. */
+        isGlobalCompletion: boolean;
+        isMemberCompletion: boolean;
+        /**
+         * true when the current location also allows for a new identifier
+         */
+        isNewIdentifierLocation: boolean;
+        entries: CompletionEntry[];
+    }
+    interface CompletionEntry {
+        name: string;
+        kind: ScriptElementKind;
+        kindModifiers?: string;
+        sortText: string;
+        insertText?: string;
+        /**
+         * An optional span that indicates the text to be replaced by this completion item.
+         * If present, this span should be used instead of the default one.
+         * It will be set if the required span differs from the one generated by the default replacement behavior.
+         */
+        replacementSpan?: TextSpan;
+        hasAction?: true;
+        source?: string;
+        isRecommended?: true;
+    }
+    interface CompletionEntryDetails {
+        name: string;
+        kind: ScriptElementKind;
+        kindModifiers: string;
+        displayParts: SymbolDisplayPart[];
+        documentation?: SymbolDisplayPart[];
+        tags?: JSDocTagInfo[];
+        codeActions?: CodeAction[];
+        source?: SymbolDisplayPart[];
+    }
+    // Must be a const enum because this module doesn't exist at runtime
+    const enum ScriptElementKind {
+        unknown = "",
+        warning = "warning",
+        /** predefined type (void) or keyword (class) */
+        keyword = "keyword",
+        /** top level script node */
+        scriptElement = "script",
+        /** module foo {} */
+        moduleElement = "module",
+        /** class X {} */
+        classElement = "class",
+        /** var x = class X {} */
+        localClassElement = "local class",
+        /** interface Y {} */
+        interfaceElement = "interface",
+        /** type T = ... */
+        typeElement = "type",
+        /** enum E */
+        enumElement = "enum",
+        enumMemberElement = "enum member",
+        /**
+         * Inside module and script only
+         * const v = ..
+         */
+        variableElement = "var",
+        /** Inside function */
+        localVariableElement = "local var",
+        /**
+         * Inside module and script only
+         * function f() { }
+         */
+        functionElement = "function",
+        /** Inside function */
+        localFunctionElement = "local function",
+        /** class X { [public|private]* foo() {} } */
+        memberFunctionElement = "method",
+        /** class X { [public|private]* [get|set] foo:number; } */
+        memberGetAccessorElement = "getter",
+        memberSetAccessorElement = "setter",
+        /**
+         * class X { [public|private]* foo:number; }
+         * interface Y { foo:number; }
+         */
+        memberVariableElement = "property",
+        /** class X { constructor() { } } */
+        constructorImplementationElement = "constructor",
+        /** interface Y { ():number; } */
+        callSignatureElement = "call",
+        /** interface Y { []:number; } */
+        indexSignatureElement = "index",
+        /** interface Y { new():Y; } */
+        constructSignatureElement = "construct",
+        /** function foo(*Y*: string) */
+        parameterElement = "parameter",
+        typeParameterElement = "type parameter",
+        primitiveType = "primitive type",
+        label = "label",
+        alias = "alias",
+        constElement = "const",
+        letElement = "let",
+        directory = "directory",
+        externalModuleName = "external module name",
+        /**
+         * <JsxTagName attribute1 attribute2={0} />
+         */
+        jsxAttribute = "JSX attribute",
+        /** String literal */
+        string = "string"
+    }
 }

--- a/src/tsMode.ts
+++ b/src/tsMode.ts
@@ -11,8 +11,8 @@ import * as languageFeatures from './languageFeatures';
 
 import Uri = monaco.Uri;
 
-let javaScriptWorker: (first: Uri, ...more: Uri[]) => Promise<TypeScriptWorker>;
-let typeScriptWorker: (first: Uri, ...more: Uri[]) => Promise<TypeScriptWorker>;
+let javaScriptWorker: (...uris: Uri[]) => Promise<TypeScriptWorker>;
+let typeScriptWorker: (...uris: Uri[]) => Promise<TypeScriptWorker>;
 
 export function setupTypeScript(defaults: LanguageServiceDefaultsImpl): void {
 	typeScriptWorker = setupMode(
@@ -28,7 +28,7 @@ export function setupJavaScript(defaults: LanguageServiceDefaultsImpl): void {
 	);
 }
 
-export function getJavaScriptWorker(): Promise<(first: Uri, ...more: Uri[]) => Promise<TypeScriptWorker>> {
+export function getJavaScriptWorker(): Promise<(...uris: Uri[]) => Promise<TypeScriptWorker>> {
 	return new Promise((resolve, reject) => {
 		if (!javaScriptWorker) {
 			return reject("JavaScript not registered!");
@@ -38,7 +38,7 @@ export function getJavaScriptWorker(): Promise<(first: Uri, ...more: Uri[]) => P
 	});
 }
 
-export function getTypeScriptWorker(): Promise<(first: Uri, ...more: Uri[]) => Promise<TypeScriptWorker>> {
+export function getTypeScriptWorker(): Promise<(...uris: Uri[]) => Promise<TypeScriptWorker>> {
 	return new Promise((resolve, reject) => {
 		if (!typeScriptWorker) {
 			return reject("TypeScript not registered!");
@@ -48,11 +48,11 @@ export function getTypeScriptWorker(): Promise<(first: Uri, ...more: Uri[]) => P
 	});
 }
 
-function setupMode(defaults: LanguageServiceDefaultsImpl, modeId: string): (first: Uri, ...more: Uri[]) => Promise<TypeScriptWorker> {
+function setupMode(defaults: LanguageServiceDefaultsImpl, modeId: string): (...uris: Uri[]) => Promise<TypeScriptWorker> {
 
 	const client = new WorkerManager(modeId, defaults);
-	const worker = (first: Uri, ...more: Uri[]): Promise<TypeScriptWorker> => {
-		return client.getLanguageServiceWorker(...[first].concat(more));
+	const worker = (...uris: Uri[]): Promise<TypeScriptWorker> => {
+		return client.getLanguageServiceWorker(...uris);
 	};
 
 	monaco.languages.registerCompletionItemProvider(modeId, new languageFeatures.SuggestAdapter(worker));

--- a/src/tsWorker.ts
+++ b/src/tsWorker.ts
@@ -20,7 +20,7 @@ const ES6_LIB = {
 	CONTENTS: lib_es6_dts
 };
 
-export class TypeScriptWorker implements ts.LanguageServiceHost {
+export class TypeScriptWorker implements ts.LanguageServiceHost, monaco.languages.typescript.TypeScriptWorker {
 
 	// --- model sync -----------------------
 
@@ -123,7 +123,7 @@ export class TypeScriptWorker implements ts.LanguageServiceHost {
 
 	// --- language features
 
-	private static clearFiles(diagnostics: ts.Diagnostic[]) {
+	private static clearFiles(diagnostics: ts.Diagnostic[]): monaco.languages.typescript.Diagnostic[] {
 		// Clear the `file` field, which cannot be JSON'yfied because it
 		// contains cyclic data structures.
 		diagnostics.forEach(diag => {
@@ -133,30 +133,27 @@ export class TypeScriptWorker implements ts.LanguageServiceHost {
 				related.forEach(diag2 => diag2.file = undefined);
 			}
 		});
+		return <monaco.languages.typescript.Diagnostic[]>diagnostics;
 	}
 
-	getSyntacticDiagnostics(fileName: string): Promise<ts.Diagnostic[]> {
+	getSyntacticDiagnostics(fileName: string): Promise<monaco.languages.typescript.Diagnostic[]> {
 		const diagnostics = this._languageService.getSyntacticDiagnostics(fileName);
-		TypeScriptWorker.clearFiles(diagnostics);
-		return Promise.resolve(diagnostics);
+		return Promise.resolve(TypeScriptWorker.clearFiles(diagnostics));
 	}
 
-	getSemanticDiagnostics(fileName: string): Promise<ts.Diagnostic[]> {
+	getSemanticDiagnostics(fileName: string): Promise<monaco.languages.typescript.Diagnostic[]> {
 		const diagnostics = this._languageService.getSemanticDiagnostics(fileName);
-		TypeScriptWorker.clearFiles(diagnostics);
-		return Promise.resolve(diagnostics);
+		return Promise.resolve(TypeScriptWorker.clearFiles(diagnostics));
 	}
 
-	getSuggestionDiagnostics(fileName: string): Promise<ts.DiagnosticWithLocation[]> {
+	getSuggestionDiagnostics(fileName: string): Promise<monaco.languages.typescript.Diagnostic[]> {
 		const diagnostics = this._languageService.getSuggestionDiagnostics(fileName);
-		TypeScriptWorker.clearFiles(diagnostics);
-		return Promise.resolve(diagnostics);
+		return Promise.resolve(TypeScriptWorker.clearFiles(diagnostics));
 	}
 
-	getCompilerOptionsDiagnostics(fileName: string): Promise<ts.Diagnostic[]> {
+	getCompilerOptionsDiagnostics(fileName: string): Promise<monaco.languages.typescript.Diagnostic[]> {
 		const diagnostics = this._languageService.getCompilerOptionsDiagnostics();
-		TypeScriptWorker.clearFiles(diagnostics);
-		return Promise.resolve(diagnostics);
+		return Promise.resolve(TypeScriptWorker.clearFiles(diagnostics));
 	}
 
 	getCompletionsAtPosition(fileName: string, position: number): Promise<ts.CompletionInfo | undefined> {

--- a/src/tsconfig.esm.json
+++ b/src/tsconfig.esm.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": true,
     "outDir": "../release/esm",
     "target": "es5",
     "lib": [

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -3,7 +3,6 @@
     "module": "amd",
     "moduleResolution": "node",
     "outDir": "../release/dev",
-    "declaration": true,
     "target": "es5",
     "lib": [
       "dom",


### PR DESCRIPTION
Update `monaco.d.ts` with a definition for `TypeScriptWorker` and a few of the types from `typescript` that it depends on, and use the proper return type for `getTypeScriptWorker`/`getJavaScriptWorker`.

To avoid polluting the `monaco.languages.typescript` module and its docs, I only copied in a few of the `typescript` types (lacking a better heuristic, the ones I need to use) and used `any` for the rest, with comments about the actual types. You can see what it would look like with all the types in [this commit](https://github.com/microsoft/monaco-typescript/commit/3f8210652c3013ea5e28a3a11a070ec9cd33e286) (note I had them in a separate `monaco.languages.typescript.ts` namespace at the time), and I could add them back if preferable.

Also update `LanguageServiceDefaults` types to add some methods that were missing, and update `CompilerOptions` to add newer compiler options.

Remove the `declaration: true` setting from tsconfig since the unqualified references to `monaco` in the generated files can cause problems in other projects (and since those generated files don't impact the final `editor.api.d.ts`).