### PR TITLE
Allow access to read files which workers host, notably the default dts

### DIFF
--- a/src/monaco.d.ts
+++ b/src/monaco.d.ts
@@ -276,6 +276,11 @@ declare module monaco.languages.typescript {
         getSuggestionDiagnostics(fileName: string): Promise<Diagnostic[]>;
 
         /**
+         * Get the content of a given file.
+         */
+        getScriptText(fileName: string): Promise<string | undefined>;
+
+        /**
          * Get diagnostic messages related to the current compiler options.
          * @param fileName Not used
          */

--- a/src/tsWorker.ts
+++ b/src/tsWorker.ts
@@ -69,7 +69,7 @@ export class TypeScriptWorker implements ts.LanguageServiceHost, monaco.language
 		return '';
 	}
 
-	getScriptSnapshot(fileName: string): ts.IScriptSnapshot | undefined {
+	getScriptText(fileName: string): string | undefined {
 		let text: string;
 		let model = this._getModel(fileName);
 		if (model) {
@@ -85,6 +85,15 @@ export class TypeScriptWorker implements ts.LanguageServiceHost, monaco.language
 		} else if (fileName === ES6_LIB.NAME) {
 			text = ES6_LIB.CONTENTS;
 		} else {
+			return;
+		}
+
+		return text;
+	}
+
+	getScriptSnapshot(fileName: string): ts.IScriptSnapshot | undefined {
+		const text = this.getScriptText(fileName);
+		if (!text) {
 			return;
 		}
 
@@ -200,12 +209,12 @@ export class TypeScriptWorker implements ts.LanguageServiceHost, monaco.language
 		return Promise.resolve(this._languageService.getFormattingEditsAfterKeystroke(fileName, postion, ch, options));
 	}
 
-	findRenameLocations(fileName: string, positon: number, findInStrings: boolean, findInComments: boolean, providePrefixAndSuffixTextForRename: boolean): Promise<readonly ts.RenameLocation[] | undefined> {
-		return Promise.resolve(this._languageService.findRenameLocations(fileName, positon, findInStrings, findInComments, providePrefixAndSuffixTextForRename));
+	findRenameLocations(fileName: string, position: number, findInStrings: boolean, findInComments: boolean, providePrefixAndSuffixTextForRename: boolean): Promise<readonly ts.RenameLocation[] | undefined> {
+		return Promise.resolve(this._languageService.findRenameLocations(fileName, position, findInStrings, findInComments, providePrefixAndSuffixTextForRename));
 	}
 
-	getRenameInfo(fileName: string, positon: number, options: ts.RenameInfoOptions): Promise<ts.RenameInfo> {
-		return Promise.resolve(this._languageService.getRenameInfo(fileName, positon, options));
+	getRenameInfo(fileName: string, position: number, options: ts.RenameInfoOptions): Promise<ts.RenameInfo> {
+		return Promise.resolve(this._languageService.getRenameInfo(fileName, position, options));
 	}
 
 	getEmitOutput(fileName: string): Promise<ts.EmitOutput> {

--- a/src/tsWorker.ts
+++ b/src/tsWorker.ts
@@ -69,7 +69,11 @@ export class TypeScriptWorker implements ts.LanguageServiceHost, monaco.language
 		return '';
 	}
 
-	getScriptText(fileName: string): string | undefined {
+	getScriptText(fileName: string): Promise<string | undefined> {
+		return Promise.resolve(this._getScriptText(fileName));
+	}
+
+	_getScriptText(fileName: string): string | undefined {
 		let text: string;
 		let model = this._getModel(fileName);
 		if (model) {
@@ -92,7 +96,7 @@ export class TypeScriptWorker implements ts.LanguageServiceHost, monaco.language
 	}
 
 	getScriptSnapshot(fileName: string): ts.IScriptSnapshot | undefined {
-		const text = this.getScriptText(fileName);
+		const text = this._getScriptText(fileName);
 		if (!text) {
 			return;
 		}


### PR DESCRIPTION
Right now there isn't a way to get access to default dts file hosted inside the worker processes. `getScriptSnapshot` returns an object with three functions which can't get serialized, and that's kinda your only entry point to access these dts files.

I'd like to be able to create a ts.Program which replicates what's going on in your editor exactly, and that only really works if I can ask for the text at a particular file.