### PR TITLE
Use bundled ESNext

### DIFF
--- a/scripts/importTypescript.js
+++ b/scripts/importTypescript.js
@@ -50,8 +50,12 @@ export const typescriptVersion = "${typeScriptDependencyVersion}";\n`
 	// \/[*/] matches the start of a comment (single or multi-line).
 	// ^\s+\*[^/] matches (presumably) a later line of a multi-line comment.
 	const tsServicesNoCommentedRequire = tsServices.replace(/(\/[*/]|^\s+\*[^/]).*\brequire\(.*/gm, '');
-	const linesWithRequire = tsServicesNoCommentedRequire.match(/^.*?\brequire\(.*$/gm);
-	if (linesWithRequire && linesWithRequire.length) {
+	const linesWithRequire = tsServicesNoCommentedRequire.match(/^.*?\brequire\(.*$/gm)
+
+	// Allow error messages to include references to require() in their strings
+	const runtimeRequires = linesWithRequire && linesWithRequire.filter(l => !l.includes(": diag("))
+
+	if (runtimeRequires && runtimeRequires.length && linesWithRequire) {
 		console.error('Found new require() calls on the following lines. These should be removed to avoid breaking webpack builds.\n');
 		console.error(linesWithRequire.join('\n'));
 		process.exit(1);

--- a/scripts/importTypescript.js
+++ b/scripts/importTypescript.js
@@ -128,7 +128,7 @@ function importLibs() {
 	};
 
 	enqueue('');
-	enqueue('es2015');
+	enqueue('esnext');
 
 	var result = [];
 	while (queue.length > 0) {
@@ -203,8 +203,8 @@ ${generatedNote}`;
 /** This is the DTS which is used when the target is ES6 or below */
 export const lib_es5_bundled_dts = lib_dts;
 
-/** This is the DTS which is used by default in monaco-typescript, and when the target is 2015 or above */
-export const lib_es2015_bundled_dts = lib_es2015_dts + "" + lib_dom_dts + "" + lib_webworker_importscripts_dts + "" + lib_scripthost_dts + "";
+/** This is the DTS which is used by default in monaco-typescript, and when the target is 2015 or above, which contains the most accurate reflection of the current runtime */
+export const lib_es2015_bundled_dts = lib_esnext_dts + "" + lib_dom_dts + "" + lib_webworker_importscripts_dts + "" + lib_scripthost_dts + "";
 `
 
 	var dstPath = path.join(TYPESCRIPT_LIB_DESTINATION, 'lib.ts');


### PR DESCRIPTION
OK, this one is more speculative for Monaco in general - but it is what we're going with in the TypeScript Playground. 

Effectively, this PR via https://github.com/microsoft/monaco-typescript/commit/73190f9ed75a6c6a82d3cf8f8d4089447bc875d4 provides the bundled lib dts files for ESNext to anyone using ES2015 and above, that means a lot of expected options will be in the autocomplete all the time. I've got the deploy process using this but will need to see what happens on nightlies to verify it doesn't self destruct.