### PR TITLE
Fix a crash in getValidSourceFile when the text content is empty

### DIFF
--- a/src/tsWorker.ts
+++ b/src/tsWorker.ts
@@ -97,7 +97,7 @@ export class TypeScriptWorker implements ts.LanguageServiceHost, monaco.language
 
 	getScriptSnapshot(fileName: string): ts.IScriptSnapshot | undefined {
 		const text = this._getScriptText(fileName);
-		if (!text) {
+		if (text === undefined) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes 

![Screen Shot 2020-06-18 at 9 21 47 AM](https://user-images.githubusercontent.com/49038/85025258-27fd6880-b145-11ea-8dfa-01cff17af8d6.png)

Thanks to @pankajk07 highlighting [it here](https://github.com/microsoft/monaco-typescript/commit/a5b927fca1b6b204bf01d43c601a961f9f66b099#r39999378)