### PR TITLE
Format signature and parameter documentation as Markdown

### DIFF
--- a/src/languageFeatures.ts
+++ b/src/languageFeatures.ts
@@ -478,13 +478,17 @@ export class SignatureHelpAdapter extends Adapter implements monaco.languages.Si
 				parameters: []
 			};
 
-			signature.documentation = displayPartsToString(item.documentation);
+			signature.documentation = {
+				value: displayPartsToString(item.documentation)
+			};
 			signature.label += displayPartsToString(item.prefixDisplayParts);
 			item.parameters.forEach((p, i, a) => {
 				const label = displayPartsToString(p.displayParts);
 				const parameter: monaco.languages.ParameterInformation = {
 					label: label,
-					documentation: displayPartsToString(p.documentation)
+					documentation: {
+						value: displayPartsToString(p.documentation)
+					}
 				};
 				signature.label += label;
 				signature.parameters.push(parameter);


### PR DESCRIPTION
So you can use Markdown formatting in the parameter documentation.

```js
/**
 * Does something.
 *
 * [Documentation](http://www.google.com)
 * @param {string} a This parameter is *important* and uses `code`.
 */
function test(a) {

}
```

![grafik](https://user-images.githubusercontent.com/25029871/91976040-ac14c480-ed20-11ea-8b2f-35b3f49e946f.png)
