### PR TITLE
Adopt "deprecated" API

### DIFF
--- a/src/languageFeatures.ts
+++ b/src/languageFeatures.ts
@@ -460,6 +460,10 @@ export class SuggestAdapter
 				range = new Range(p1.lineNumber, p1.column, p2.lineNumber, p2.column);
 			}
 
+			const tags: languages.CompletionItemTag[] = [];
+			if (entry.kindModifiers?.indexOf('deprecated') !== -1)
+				tags.push(languages.CompletionItemTag.Deprecated);
+
 			return {
 				uri: resource,
 				position: position,
@@ -467,7 +471,8 @@ export class SuggestAdapter
 				label: entry.name,
 				insertText: entry.name,
 				sortText: entry.sortText,
-				kind: SuggestAdapter.convertKind(entry.kind)
+				kind: SuggestAdapter.convertKind(entry.kind),
+				tags
 			};
 		});
 

--- a/src/languageFeatures.ts
+++ b/src/languageFeatures.ts
@@ -508,7 +508,7 @@ export class SuggestAdapter
 			kind: SuggestAdapter.convertKind(details.kind),
 			detail: displayPartsToString(details.displayParts),
 			documentation: {
-				value: displayPartsToString(details.documentation)
+				value: SuggestAdapter.createDocumentationString(details)
 			}
 		};
 	}
@@ -544,6 +544,25 @@ export class SuggestAdapter
 		}
 
 		return languages.CompletionItemKind.Property;
+	}
+
+	private static createDocumentationString(
+		details: ts.CompletionEntryDetails
+	): string {
+		let documentationString = displayPartsToString(details.documentation);
+		if (details.tags) {
+			for (const tag of details.tags) {
+				documentationString += `\n\n*@${tag.name}*`;
+				if (tag.name === 'param' && tag.text) {
+					const [paramName, ...rest] = tag.text.split(' ');
+					documentationString += `\`${paramName}\``;
+					if (rest.length > 0) documentationString += ` — ${rest.join(' ')}`;
+				} else if (tag.text) {
+					documentationString += ` — ${tag.text}`;
+				}
+			}
+		}
+		return documentationString;
 	}
 }
 

--- a/src/languageFeatures.ts
+++ b/src/languageFeatures.ts
@@ -330,6 +330,10 @@ export class DiagnosticsAdapter extends Adapter {
 			column: endColumn
 		} = model.getPositionAt(diagStart + diagLength);
 
+		const tags: MarkerTag[] = [];
+		if (diag.reportsUnnecessary) tags.push(MarkerTag.Unnecessary);
+		if (diag.reportsDeprecated) tags.push(MarkerTag.Deprecated);
+
 		return {
 			severity: this._tsDiagnosticCategoryToMarkerSeverity(diag.category),
 			startLineNumber,
@@ -338,7 +342,7 @@ export class DiagnosticsAdapter extends Adapter {
 			endColumn,
 			message: flattenDiagnosticMessageText(diag.messageText, '\n'),
 			code: diag.code.toString(),
-			tags: diag.reportsUnnecessary ? [MarkerTag.Unnecessary] : [],
+			tags,
 			relatedInformation: this._convertRelatedInformation(
 				model,
 				diag.relatedInformation

--- a/src/languageFeatures.ts
+++ b/src/languageFeatures.ts
@@ -552,18 +552,23 @@ export class SuggestAdapter
 		let documentationString = displayPartsToString(details.documentation);
 		if (details.tags) {
 			for (const tag of details.tags) {
-				documentationString += `\n\n*@${tag.name}*`;
-				if (tag.name === 'param' && tag.text) {
-					const [paramName, ...rest] = tag.text.split(' ');
-					documentationString += `\`${paramName}\``;
-					if (rest.length > 0) documentationString += ` — ${rest.join(' ')}`;
-				} else if (tag.text) {
-					documentationString += ` — ${tag.text}`;
-				}
+				documentationString += `\n\n${tagToString(tag)}`;
 			}
 		}
 		return documentationString;
 	}
+}
+
+function tagToString(tag: ts.JSDocTagInfo): string {
+	let tagLabel = `*@${tag.name}*`;
+	if (tag.name === 'param' && tag.text) {
+		const [paramName, ...rest] = tag.text.split(' ');
+		tagLabel += `\`${paramName}\``;
+		if (rest.length > 0) tagLabel += ` — ${rest.join(' ')}`;
+	} else if (tag.text) {
+		tagLabel += ` — ${tag.text}`;
+	}
+	return tagLabel;
 }
 
 export class SignatureHelpAdapter
@@ -653,18 +658,7 @@ export class QuickInfoAdapter
 
 		const documentation = displayPartsToString(info.documentation);
 		const tags = info.tags
-			? info.tags
-					.map((tag) => {
-						const label = `*@${tag.name}*`;
-						if (!tag.text) {
-							return label;
-						}
-						return (
-							label +
-							(tag.text.match(/\r\n|\n/g) ? ' \n' + tag.text : ` - ${tag.text}`)
-						);
-					})
-					.join('  \n\n')
+			? info.tags.map((tag) => tagToString(tag)).join('  \n\n')
 			: '';
 		const contents = displayPartsToString(info.displayParts);
 		return {


### PR DESCRIPTION
Adopts tags to mark elements as deprecated in diagnostics and suggestion items so that they can be rendered with a strikethrough syle.

Editor and suggestion item:
![image](https://user-images.githubusercontent.com/25029871/92418521-281b6c00-f168-11ea-9ffe-409ebba4009b.png)

I also added tags (e.g. `@param`, `@deprecated`) to the documentation of suggestion items. This helps to discover alternatives to deprecated items if they are documented appropriately:
![image](https://user-images.githubusercontent.com/25029871/92418557-6e70cb00-f168-11ea-9200-45a4f332605a.png)

Finally I aligned the representation of tags in suggestion documentation and hover information (this existed before and I replaced it with the new logic). Let me know if this is OK. I tried to adopt the representation of VS Code as far as `@param` tags are concerned, where the parameter name is represented as code and the actual documentation text is appended with a separation character:
![image](https://user-images.githubusercontent.com/25029871/92418648-ea6b1300-f168-11ea-85a0-8ceae2ae5cf2.png)

Example code:
```js
class Test {
	/**
	 * asdf
	 * @param {number} a testing `code`
	 * @param {number} b testing more `code`
	 * @deprecated use `bar` instead
	 */
	foo(a, b) { }

	bar(a, b) { }
}

new Test().foo(1, 2);

/** @deprecated use that other function instead */
function test() { }

test()
```