### PR TITLE
Allows setting lib with shortnames

### DIFF
--- a/src/tsWorker.ts
+++ b/src/tsWorker.ts
@@ -71,11 +71,14 @@ export class TypeScriptWorker
 	_getScriptText(fileName: string): string | undefined {
 		let text: string;
 		let model = this._getModel(fileName);
+		const libizedFileName = 'lib.' + fileName + '.d.ts';
 		if (model) {
 			// a true editor model
 			text = model.getValue();
 		} else if (fileName in libFileMap) {
 			text = libFileMap[fileName];
+		} else if (libizedFileName in libFileMap) {
+			text = libFileMap[libizedFileName];
 		} else if (fileName in this._extraLibs) {
 			// extra lib
 			text = this._extraLibs[fileName].content;


### PR DESCRIPTION
Discussion at the end of #64  - but roughly, the switch to allow `target` and `lib` to control the .d.ts acquisition didn't include a TS nicety in that it handles writing `esnext` in the `lib` but that is then converted to a fs lookup for `lib.esnext.d.ts`. 

This PR adds that same handling.