### PR TITLE
Use typescript language for hover tooltip header

### DIFF
--- a/src/languageFeatures.ts
+++ b/src/languageFeatures.ts
@@ -670,7 +670,7 @@ export class QuickInfoAdapter
 			range: this._textSpanToRange(model, info.textSpan),
 			contents: [
 				{
-					value: '```js\n' + contents + '\n```\n'
+					value: '```typescript\n' + contents + '\n```\n'
 				},
 				{
 					value: documentation + (tags ? '\n\n' + tags : '')


### PR DESCRIPTION
When using a custom token provider for enhanced syntax highlighting, there is much more value in having the hover tooltip contents be rendered with the typescript tokenizer. With this, we can highlight typescript tokens like enum, type identifiers, etc.

VSCode [appears to do the same](https://github.com/microsoft/vscode/blob/master/extensions/typescript-language-features/src/languageFeatures/hover.ts#L62) in the `typescript-language-features` extension