### PR TITLE
Keep fileName property of diagnostic objects and related information

### DIFF
--- a/src/languageFeatures.ts
+++ b/src/languageFeatures.ts
@@ -4,7 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import { LanguageServiceDefaults } from './monaco.contribution';
+import {
+	Diagnostic,
+	DiagnosticRelatedInformation,
+	LanguageServiceDefaults
+} from './monaco.contribution';
 import type * as ts from './lib/typescriptServices';
 import type { TypeScriptWorker } from './tsWorker';
 import { libFileSet } from './lib/lib.index';
@@ -244,7 +248,7 @@ export class DiagnosticsAdapter extends Adapter {
 			return;
 		}
 
-		const promises: Promise<ts.Diagnostic[]>[] = [];
+		const promises: Promise<Diagnostic[]>[] = [];
 		const {
 			noSyntaxValidation,
 			noSemanticValidation,
@@ -297,7 +301,7 @@ export class DiagnosticsAdapter extends Adapter {
 		);
 	}
 
-	private _convertDiagnostics(model: editor.ITextModel, diag: ts.Diagnostic): editor.IMarkerData {
+	private _convertDiagnostics(model: editor.ITextModel, diag: Diagnostic): editor.IMarkerData {
 		const diagStart = diag.start || 0;
 		const diagLength = diag.length || 1;
 		const { lineNumber: startLineNumber, column: startColumn } = model.getPositionAt(diagStart);
@@ -328,7 +332,7 @@ export class DiagnosticsAdapter extends Adapter {
 
 	private _convertRelatedInformation(
 		model: editor.ITextModel,
-		relatedInformation?: ts.DiagnosticRelatedInformation[]
+		relatedInformation?: DiagnosticRelatedInformation[]
 	): editor.IRelatedInformation[] | undefined {
 		if (!relatedInformation) {
 			return;

--- a/src/monaco.contribution.ts
+++ b/src/monaco.contribution.ts
@@ -187,15 +187,16 @@ interface DiagnosticMessageChain {
 export interface Diagnostic extends DiagnosticRelatedInformation {
 	/** May store more in future. For now, this will simply be `true` to indicate when a diagnostic is an unused-identifier diagnostic. */
 	reportsUnnecessary?: {};
+	reportsDeprecated?: {};
 	source?: string;
 	relatedInformation?: DiagnosticRelatedInformation[];
 }
-interface DiagnosticRelatedInformation {
+export interface DiagnosticRelatedInformation {
 	/** Diagnostic category: warning = 0, error = 1, suggestion = 2, message = 3 */
 	category: 0 | 1 | 2 | 3;
 	code: number;
-	/** TypeScriptWorker removes this to avoid serializing circular JSON structures. */
-	file: undefined;
+	/** TypeScriptWorker removes all but the `fileName` property to avoid serializing circular JSON structures. */
+	file: { fileName: string } | undefined;
 	start: number | undefined;
 	length: number | undefined;
 	messageText: string | DiagnosticMessageChain;

--- a/src/tsWorker.ts
+++ b/src/tsWorker.ts
@@ -179,13 +179,13 @@ export class TypeScriptWorker implements ts.LanguageServiceHost, ITypeScriptWork
 
 	private static clearFiles(diagnostics: ts.Diagnostic[]): Diagnostic[] {
 		// Clear the `file` field, which cannot be JSON'yfied because it
-		// contains cyclic data structures.
-		diagnostics.forEach((diag) => {
-			diag.file = undefined;
-			const related = <ts.Diagnostic[]>diag.relatedInformation;
-			if (related) {
-				related.forEach((diag2) => (diag2.file = undefined));
-			}
+		// contains cyclic data structures, except for the `fileName`
+		// property.
+		diagnostics.forEach((diag: Diagnostic) => {
+			diag.file = diag.file ? { fileName: diag.file.fileName } : undefined;
+			diag.relatedInformation?.forEach(
+				(diag2) => (diag2.file = diag2.file ? { fileName: diag2.file.fileName } : undefined)
+			);
 		});
 		return <Diagnostic[]>diagnostics;
 	}


### PR DESCRIPTION
Using the code below in the Monaco playground I was wondering why the related information shows the wrong file. The diagnostic references the current editor model instead of the file where the class has already been declared.
![grafik](https://user-images.githubusercontent.com/25029871/108693579-44387d00-74fe-11eb-88c9-4be894d96719.png)

This is caused by this helper function that clears the entire file object in order to avoid cyclic references during JSON serialization:
https://github.com/microsoft/monaco-typescript/blob/e8b0174a8e94647ef1e0166ec89a68d91740e3a8/src/tsWorker.ts#L180-L191

If we instead clear everything of the `file` object but the `fileName` property, we get accurate diagnostics:
![grafik](https://user-images.githubusercontent.com/25029871/108694212-10118c00-74ff-11eb-9e89-acdb66b3c46c.png)

```js
monaco.languages.typescript.javascriptDefaults.setDiagnosticsOptions({
	noSemanticValidation: false,
	noSyntaxValidation: false
});

monaco.languages.typescript.javascriptDefaults.setCompilerOptions({
	target: monaco.languages.typescript.ScriptTarget.ES6,
	allowNonTsExtensions: true
});

// extra libraries
var libSource = [
	'declare class Facts {',
	'    /**',
	'     * Returns the next fact',
	'     */',
	'    static next():string',
	'}',
].join('\n');
var libUri = 'ts:filename/facts.d.ts';
monaco.languages.typescript.javascriptDefaults.addExtraLib(libSource, libUri);
// When resolving definitions and references, the editor will try to use created models.
// Creating a model for the library allows "peek definition/references" commands to work with the library.
monaco.editor.createModel(libSource, 'typescript', monaco.Uri.parse(libUri));

monaco.editor.create(document.getElementById('container'), {
	value: 'class Facts {}',
	language: 'javascript'
});
```