### PR TITLE
add experimentalMultipleFilesDiagnostics to DiagnosticsOptions. 

### DIFF
--- a/monaco.d.ts
+++ b/monaco.d.ts
@@ -143,6 +143,7 @@ declare namespace monaco.languages.typescript {
 		noSemanticValidation?: boolean;
 		noSyntaxValidation?: boolean;
 		noSuggestionDiagnostics?: boolean;
+		experimentalMultipleFilesDiagnostics?: boolean;
 		diagnosticCodesToIgnore?: number[];
 	}
 	export interface WorkerOptions {

--- a/src/monaco.contribution.ts
+++ b/src/monaco.contribution.ts
@@ -156,6 +156,7 @@ export interface DiagnosticsOptions {
 	noSemanticValidation?: boolean;
 	noSyntaxValidation?: boolean;
 	noSuggestionDiagnostics?: boolean;
+	experimentalMultipleFilesDiagnostics?: boolean;
 	diagnosticCodesToIgnore?: number[];
 }
 
@@ -616,13 +617,13 @@ export const typescriptVersion: string = tsversion;
 
 export const typescriptDefaults: LanguageServiceDefaults = new LanguageServiceDefaultsImpl(
 	{ allowNonTsExtensions: true, target: ScriptTarget.Latest },
-	{ noSemanticValidation: false, noSyntaxValidation: false },
+	{ noSemanticValidation: false, noSyntaxValidation: false, experimentalMultipleFilesDiagnostics: false },
 	{}
 );
 
 export const javascriptDefaults: LanguageServiceDefaults = new LanguageServiceDefaultsImpl(
 	{ allowNonTsExtensions: true, allowJs: true, target: ScriptTarget.Latest },
-	{ noSemanticValidation: true, noSyntaxValidation: false },
+	{ noSemanticValidation: true, noSyntaxValidation: false, experimentalMultipleFilesDiagnostics: false },
 	{}
 );
 


### PR DESCRIPTION
Hi there, we (Wix.com) are having a performance issue when we run projects that have large amount of models (files). When navigating between models in a project that has ~300 code files with ~25K lines, it takes several seconds until the model markers appear in the editor. 
In our use case, we have multiple code scopes (frontend, backend, hybrid, etc). when navigating between models that are in a different scope, we update the extra Libs with the correct scope definition files. it triggers `onDidExtraLibsChange` which causes the performance issue described.
This PR fixes that so that the markers appears almost immediately.
Navigating between models (from a different scope) in large projects current situation:
![navigating between models current situation](https://user-images.githubusercontent.com/222435/114027608-38bbce00-9880-11eb-9244-6ee796057d43.gif)
Navigating between models (from a different scope) in large projects after this PR:
![navigating with the pr 2](https://user-images.githubusercontent.com/222435/114028504-37d76c00-9881-11eb-9b17-f2f8f2fbdb36.gif)
In the current implementation, we run the `recomputeDiagostics` handler on `editor.onDidChange` & `editor.onDidExtraLibsChange`. 
`recomputeDiagostics` fetches all editor models and for each model runs the `onModelRemoved` and `onModelAdd` handlers, which causes the performance issue.
This PR changes the implementation of `recomputeDiagostics` to only run the `onModelRemoved` and `onModelAdd` handlers on the current model. For extra safety, I put this under an optional flag (not sure the name is good enough) in `diagnosticOption` , but maybe it should be enabled by automatically to improve the performance for all consumers. Let me know what you think.