### PR TITLE
Handle the new undefined logic in TypeScript 4.4

### DIFF
--- a/src/languageFeatures.ts
+++ b/src/languageFeatures.ts
@@ -893,8 +893,9 @@ export class OutlineAdapter extends Adapter implements languages.DocumentSymbolP
 				range: this._textSpanToRange(model, item.spans[0]),
 				selectionRange: this._textSpanToRange(model, item.spans[0]),
 				tags: [],
-				containerName: containerLabel
 			};
+
+			if (containerLabel) result.containerName = containerLabel;
 
 			if (item.childItems && item.childItems.length > 0) {
 				for (let child of item.childItems) {


### PR DESCRIPTION
TS 4.4 strict introduces has a stricter interpretation of `containerName?: string`

4.3 -> OK `containerName: undefined`.
4.4 -> Not OK `containerName: undefined` because the key is either not there or definitely a string.

So, this verifies the `containerLabel` exists and then sets it on the outline item.