### PR TITLE
Build tag text correctly for all tags

### DIFF
--- a/src/languageFeatures.ts
+++ b/src/languageFeatures.ts
@@ -575,8 +575,10 @@ function tagToString(tag: ts.JSDocTagInfo): string {
 		const [paramName, ...rest] = tag.text;
 		tagLabel += `\`${paramName.text}\``;
 		if (rest.length > 0) tagLabel += ` — ${rest.map(r => r.text).join(' ')}`;
-	} else if (tag.text) {
+	} else if (Array.isArray(tag.text)) {
 		tagLabel += ` — ${tag.text.map(r => r.text).join(' ')}`;
+	} else if (tag.text) {
+		tagLabel += ` — ${tag.text}`;
 	}
 	return tagLabel;
 }

--- a/src/languageFeatures.ts
+++ b/src/languageFeatures.ts
@@ -576,7 +576,7 @@ function tagToString(tag: ts.JSDocTagInfo): string {
 		tagLabel += `\`${paramName.text}\``;
 		if (rest.length > 0) tagLabel += ` — ${rest.map(r => r.text).join(' ')}`;
 	} else if (tag.text) {
-		tagLabel += ` — ${tag.text}`;
+		tagLabel += ` — ${tag.text.map(r => r.text).join(' ')}`;
 	}
 	return tagLabel;
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/monaco-editor/issues/2523

Is this the correct way for all tag types? The typings suggest that `tag.text` is now always an array.

/cc @orta 