### PR TITLE
Publicly expose getters for the lang server and extra libs

### DIFF
--- a/src/tsWorker.ts
+++ b/src/tsWorker.ts
@@ -54,6 +54,14 @@ export class TypeScriptWorker implements ts.LanguageServiceHost, ITypeScriptWork
 		return this._compilerOptions;
 	}
 
+	getLanguageService(): ts.LanguageService {
+		return this._languageService;
+	}
+
+	getExtraLibs(): IExtraLibs {
+		return this._extraLibs;
+	}
+
 	getScriptFileNames(): string[] {
 		const allModels = this._ctx.getMirrorModels().map((model) => model.uri);
 		const models = allModels.filter((uri) => !fileNameIsLib(uri)).map((uri) => uri.toString());


### PR DESCRIPTION
Re: https://github.com/microsoft/monaco-typescript/pull/65#discussion_r667448895

Exposes getters so that subclasses can safely read these fields